### PR TITLE
Add headless build + instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY = all, test, test_no_race, rpm, clean
 
-# development copy with race detection - for a normal copy, use "go build"
 onedriver: graph/*.go graph/*.c graph/*.h logger/*.go main.go
 	go build
 
@@ -38,5 +37,5 @@ compile_flags.txt:
 # will literally purge everything: all built artifacts, all logs, all tests,
 # all files tests depend on, all auth tokens... EVERYTHING
 clean:
-	fusermount -uz mount/
+	fusermount -uz mount/ || true
 	rm -f *.db *.rpm *.deb *.log *.fa *.gz onedriver auth_tokens.json

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ ls -l mount
 fusermount -u mount
 ```
 
+A headless, Go-only binary can be built with `CGO_ENABLED=0 go build`. Note that
+this build will not have any kind of GUI for authentication (follow the text 
+instructions in the terminal).
+
 ### Running tests
 
 ```bash

--- a/graph/oauth2.go
+++ b/graph/oauth2.go
@@ -1,12 +1,5 @@
 package graph
 
-/*
-#cgo linux pkg-config: webkit2gtk-4.0
-#include "stdlib.h"
-#include "oauth2_gtk.h"
-*/
-import "C"
-
 import (
 	"encoding/json"
 	"fmt"
@@ -14,10 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 	"time"
-	"unsafe"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -86,27 +77,13 @@ func (a *Auth) Refresh() {
 	}
 }
 
-// Fetch the auth code required as the first part of oauth2 authentication.
-func getAuthCode() string {
-	authURL := authCodeURL +
+// Get the appropriate authentication URL for the Graph OAuth2 challenge.
+func getAuthURL() string {
+	return authCodeURL +
 		"?client_id=" + authClientID +
 		"&scope=" + url.PathEscape("files.readwrite.all offline_access") +
 		"&response_type=code" +
 		"&redirect_uri=" + authRedirectURL
-
-	cAuthURL := C.CString(authURL)
-	defer C.free(unsafe.Pointer(cAuthURL))
-	responseC := C.webkit_auth_window(cAuthURL)
-	defer C.free(unsafe.Pointer(responseC))
-	response := C.GoString(responseC)
-
-	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_])+")
-	code := rexp.FindString(response)
-	if len(code) == 0 {
-		log.Fatal("No validation code returned, or code was invalid. " +
-			"Please restart the application and try again.")
-	}
-	return code[5:]
 }
 
 // Exchange an auth code for a set of access tokens

--- a/graph/oauth2_gtk.c
+++ b/graph/oauth2_gtk.c
@@ -1,14 +1,8 @@
+#include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>
-
-#if defined(__linux__)
-#include <gtk/gtk.h>
 #include <webkit2/webkit2.h>
-#else
-#include <stdlib.h>
-#endif
 
-#if defined(__linux__)
 static WebKitWebView *web_view_static = NULL;
 static char *auth_redirect_value = NULL;
 
@@ -24,14 +18,11 @@ static gboolean close_web_view_cb(WebKitWebView *web_view, GtkWidget *window) {
   gtk_widget_destroy(window);
   return TRUE;
 }
-#endif
 
 /**
  * Open a popup GTK auth window and return the final redirect location.
  */
 char *webkit_auth_window(char *auth_url) {
-#if defined(__linux__)
-  // linux - hooray, we can auth via an embedded browser!
   printf("Performing initial authentication to Microsoft Graph (OneDrive API). "
          "The authentication window can be closed once you are redirected "
          "to a blank page (after \"Let this app access your info?\").\n");
@@ -58,15 +49,6 @@ char *webkit_auth_window(char *auth_url) {
   if (!auth_redirect_value) {
     auth_redirect_value = "";
   }
-#else
-  // unfortunately on windows or mac... CLI only
-  printf("Please visit the following url:\n%s\n\n", auth_url);
-
-  char *auth_redirect_value = malloc(2048);
-  printf("Please enter the redirect URL once you are redirected to a blank page "
-         "(after \"Let this app access your info?\"):\n");
-  fgets(auth_redirect_value, 2048, stdin);
-#endif
 
   return auth_redirect_value;
 }

--- a/graph/oauth2_gtk.go
+++ b/graph/oauth2_gtk.go
@@ -1,0 +1,35 @@
+// +build linux,cgo
+
+package graph
+
+/*
+#cgo linux pkg-config: webkit2gtk-4.0
+#include "stdlib.h"
+#include "oauth2_gtk.h"
+*/
+import "C"
+
+import (
+	"regexp"
+	"unsafe"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Fetch the auth code required as the first part of oauth2 authentication. Uses
+// webkit2gtk to create a popup browser.
+func getAuthCode() string {
+	cAuthURL := C.CString(getAuthURL())
+	cResponse := C.webkit_auth_window(cAuthURL)
+	response := C.GoString(cResponse)
+	C.free(unsafe.Pointer(cAuthURL))
+	C.free(unsafe.Pointer(cResponse))
+
+	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_])+")
+	code := rexp.FindString(response)
+	if len(code) == 0 {
+		log.Fatal("No validation code returned, or code was invalid. " +
+			"Please restart the application and try again.")
+	}
+	return code[5:]
+}

--- a/graph/oauth2_gtk.h
+++ b/graph/oauth2_gtk.h
@@ -1,1 +1,3 @@
+#pragma once
+
 char *webkit_auth_window(char *auth_url);

--- a/graph/oauth2_headless.go
+++ b/graph/oauth2_headless.go
@@ -1,0 +1,26 @@
+// +build !linux !cgo
+
+package graph
+
+import (
+	"fmt"
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func getAuthCode() string {
+	fmt.Printf("Please visit the following URL:\n%s\n\n", getAuthURL())
+	fmt.Println("Please enter the redirect URL once you are redirected to a " +
+		"blank page (after \"Let this app access your info?\"):")
+	var response string
+	fmt.Scanln(&response)
+
+	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_])+")
+	code := rexp.FindString(response)
+	if len(code) == 0 {
+		log.Fatal("No validation code returned, or code was invalid. " +
+			"Please restart the application and try again.")
+	}
+	return code[5:]
+}


### PR DESCRIPTION
This allows users to build a version of onedriver that does not depend on X or WebkitGTK by setting `CGO_ENABLED=0` at build time.