### PR TITLE
A little clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ your files on OneDrive!
 
 ## Building onedriver
 
-In addition to the traditional Go tooling, you will need a C compiler and
+In addition to the traditional Go tooling (see: <https://golang.org/doc/install>), you will need a C compiler and
 development headers for `webkit2gtk-4.0`. On Fedora, these can be obtained with 
 `dnf install golang gcc pkg-config webkit2gtk3-devel`. 
 On Ubuntu, these dependencies can be installed with
@@ -103,6 +103,10 @@ refers to where we want OneDrive to be mounted at (for instance, `~/OneDrive`).
 ```bash
 # create the mountpoint and determine the service name
 mkdir -p $MOUNTPOINT
+
+# ensure onedriver is configured to connect to OneDrive
+onedriver -a $MOUNTPOINT
+
 export SERVICE_NAME=$(systemd-escape --template onedriver@.service $MOUNTPOINT)
 
 # mount onedrive


### PR DESCRIPTION
As a user, I felt that there were some steps missing from this documentation. 

I initially didn't install go, I think adding a link will highlight that part of the README and make it obvious that you will need to have go installed.

Also, since I didn't go through the build and test steps, I had to work out how to get onedriver configured, so I added that to the readme too.