### PR TITLE
Server deltas now cannot delete nonempty folders

### DIFF
--- a/fs/cache_test.go
+++ b/fs/cache_test.go
@@ -73,7 +73,3 @@ func TestSamePointer(t *testing.T) {
 		t.Fatal("Item was nil!")
 	}
 }
-
-//TODO test setting a parent multiple times
-
-//TODO test removing a parent multiple times

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -51,7 +51,7 @@ type SerializeableInode struct {
 	Mode     uint32
 }
 
-// NewInode initializes a new DriveItem
+// NewInode initializes a new Inode
 func NewInode(name string, mode uint32, parent *Inode) *Inode {
 	itemParent := &graph.DriveItemParent{ID: "", Path: ""}
 	if parent != nil {
@@ -417,6 +417,13 @@ func (i *Inode) HasChanges() bool {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()
 	return i.hasChanges
+}
+
+// HasChildren returns true if the item has more than 0 children
+func (i *Inode) HasChildren() bool {
+	i.mutex.RLock()
+	defer i.mutex.RUnlock()
+	return len(i.children) > 0
 }
 
 // Fsync is a signal to ensure writes to the Inode are flushed to stable


### PR DESCRIPTION
Just obeying one of the API doc comments more explicitly and adding test cases for it.