### PR TITLE
Add retries for all upload stages

### DIFF
--- a/fs/cache.go
+++ b/fs/cache.go
@@ -258,6 +258,7 @@ func (c *Cache) DeleteID(id string) {
 		parent.mutex.Unlock()
 	}
 	c.metadata.Delete(id)
+	c.uploads.CancelUpload(id)
 }
 
 // only used for parsing

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -37,9 +37,12 @@ type UploadSession struct {
 	ExpirationDateTime time.Time `json:"expirationDateTime"`
 	Size               uint64    `json:"-"`
 	data               []byte
+	modtime            time.Time
+	retries            int
 
 	mutex sync.Mutex
 	state int
+	error // embedded error tracks errors that killed an upload
 }
 
 // UploadSessionPost is the initial post used to create an upload session
@@ -68,9 +71,10 @@ func (u *UploadSession) getState() int {
 	return u.state
 }
 
-func (u *UploadSession) setState(state int) {
+func (u *UploadSession) setState(state int, err error) {
 	u.mutex.Lock()
 	u.state = state
+	u.error = err
 	u.mutex.Unlock()
 }
 
@@ -89,9 +93,10 @@ func NewUploadSession(inode *Inode, auth *graph.Auth) (*UploadSession, error) {
 	inode.mutex.RLock()
 	// create a generic session for all files
 	session := UploadSession{
-		ID:   inode.DriveItem.ID,
-		Size: inode.DriveItem.Size,
-		data: make([]byte, inode.DriveItem.Size),
+		ID:      inode.DriveItem.ID,
+		Size:    inode.DriveItem.Size,
+		data:    make([]byte, inode.DriveItem.Size),
+		modtime: *inode.DriveItem.ModTime,
 	}
 	if inode.data == nil {
 		log.WithFields(log.Fields{
@@ -103,30 +108,6 @@ func NewUploadSession(inode *Inode, auth *graph.Auth) (*UploadSession, error) {
 	}
 	copy(session.data, *inode.data)
 	inode.mutex.RUnlock()
-
-	if session.isLargeSession() {
-		// must create a formal upload session with the API
-		sessionResp, _ := json.Marshal(UploadSessionPost{
-			ConflictBehavior: "replace",
-			FileSystemInfo: FileSystemInfo{
-				LastModifiedDateTime: time.Unix(int64(inode.ModTime()), 0),
-			},
-		})
-
-		resp, err := graph.Post(
-			fmt.Sprintf("/me/drive/items/%s/createUploadSession", session.ID),
-			auth,
-			bytes.NewReader(sessionResp),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// populates UploadURL/expiration
-		if err = json.Unmarshal(resp, &session); err != nil {
-			return nil, err
-		}
-	}
 	return &session, nil
 }
 
@@ -134,14 +115,19 @@ func NewUploadSession(inode *Inode, auth *graph.Auth) (*UploadSession, error) {
 func (u *UploadSession) cancel(auth *graph.Auth) {
 	// is it an actual API upload session?
 	if u.isLargeSession() {
-		// dont care about result, this is purely us being polite to the server
-		go graph.Delete(u.UploadURL, auth)
+		state := u.getState()
+		if state == started || state == errored {
+			// dont care about result, this is purely us being polite to the server
+			go graph.Delete(u.UploadURL, auth)
+		}
 	}
 }
 
 // Internal method used for uploading individual chunks of a DriveItem. We have
 // to make things this way because the internal Put func doesn't work all that
-// well when we need to add custom headers.
+// well when we need to add custom headers. Will return without an error if
+// irrespective of HTTP status (errors are reserved for stuff that prevented
+// the HTTP request at all).
 func (u *UploadSession) uploadChunk(auth *graph.Auth, offset uint64) ([]byte, int, error) {
 	if u.UploadURL == "" {
 		return nil, -1, errors.New("uploadSession UploadURL cannot be empty")
@@ -175,9 +161,6 @@ func (u *UploadSession) uploadChunk(auth *graph.Auth, offset uint64) ([]byte, in
 	resp, err := client.Do(request)
 	if err != nil {
 		// this is a serious error, not simply one with a non-200 return code
-		log.WithField(
-			"id", u.ID,
-		).Error("Error during file upload, terminating upload session.")
 		return nil, -1, err
 	}
 	defer resp.Body.Close()
@@ -186,12 +169,14 @@ func (u *UploadSession) uploadChunk(auth *graph.Auth, offset uint64) ([]byte, in
 }
 
 // Upload copies the file's contents to the server. Should only be called as a
-// goroutine, or it can potentially block for a very long time.
+// goroutine, or it can potentially block for a very long time. The uploadSession.error
+// field contains errors to be handled if called as a goroutine.
 func (u *UploadSession) Upload(auth *graph.Auth) error {
 	log.WithField("id", u.ID).Debug("Uploading file.")
-	u.setState(started)
+	u.setState(started, nil)
 	if !u.isLargeSession() {
-		resp, err := graph.Put(
+		// small files handled in this block
+		_, err := graph.Put(
 			fmt.Sprintf("/me/drive/items/%s/content", u.ID),
 			auth,
 			bytes.NewReader(u.data),
@@ -199,25 +184,44 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 		if err != nil && strings.Contains(err.Error(), "resourceModified") {
 			// retry the request after a second, likely the server is having issues
 			time.Sleep(time.Second)
-			resp, err = graph.Put(
+			_, err = graph.Put(
 				fmt.Sprintf("/me/drive/items/%s/content", u.ID),
 				auth,
 				bytes.NewReader(u.data),
 			)
 		}
 
-		u.setState(complete)
+		u.setState(complete, nil)
 		if err != nil {
-			u.setState(errored)
-			log.WithFields(log.Fields{
-				"id":       u.ID,
-				"response": string(resp),
-				"err":      err,
-			}).Error("Error during small file upload.")
+			// upload has failed
+			u.setState(errored, err)
 		}
 		return err
 	}
 
+	// must create a formal upload session with the API for large sessions
+	sessionPostData, _ := json.Marshal(UploadSessionPost{
+		ConflictBehavior: "replace",
+		FileSystemInfo: FileSystemInfo{
+			LastModifiedDateTime: u.modtime,
+		},
+	})
+	resp, err := graph.Post(
+		fmt.Sprintf("/me/drive/items/%s/createUploadSession", u.ID),
+		auth,
+		bytes.NewReader(sessionPostData),
+	)
+	if err != nil {
+		u.setState(errored, err)
+		return err
+	}
+	// populates UploadURL/expiration
+	if err = json.Unmarshal(resp, &u); err != nil {
+		u.setState(errored, err)
+		return err
+	}
+
+	// api upload session created successfully, now do actual content upload
 	nchunks := int(math.Ceil(float64(u.Size) / float64(chunkSize)))
 	for i := 0; i < nchunks; i++ {
 		resp, status, err := u.uploadChunk(auth, uint64(i)*chunkSize)
@@ -227,54 +231,39 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 				"chunk":   i,
 				"nchunks": nchunks,
 				"err":     err,
-			}).Error("Error during chunk upload, cancelling upload session.")
-			u.cancel(auth)
+			}).Error("Error during chunk upload.")
+			u.setState(errored, err)
 			return err
 		}
 
-		// retry server-side failures with an exponential back-off strategy
+		// retry server-side failures with an exponential back-off strategy. Will not
+		// exit this loop unless it receives a non 5xx error or serious failure
 		for backoff := 1; status >= 500; backoff *= 2 {
 			log.WithFields(log.Fields{
 				"id":      u.ID,
 				"chunk":   i,
 				"nchunks": nchunks,
-			}).Errorf("The OneDrive server is having issues, retrying upload in %ds.", backoff)
-			resp, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
-			if err != nil {
+			}).Errorf("The OneDrive server is having issues, retrying chunk upload in %ds.", backoff)
+			time.Sleep(time.Duration(backoff) * time.Second)
+			_, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
+			if err != nil { // a serious, non 4xx/5xx error
 				log.WithFields(log.Fields{
-					"id":       u.ID,
-					"response": resp,
-					"err":      err,
-				}).Error("Failed while retrying upload. Killing upload session.")
-				u.cancel(auth)
+					"id":  u.ID,
+					"err": err,
+				}).Error("Failed while retrying chunk upload after server-side error.")
+				u.setState(errored, err)
 				return err
 			}
 		}
 
 		// handle client-side errors
-		if status == 404 {
-			log.WithFields(log.Fields{
-				"id":   u.ID,
-				"code": status,
-			}).Error("Upload session expired, cancelling upload.")
-			// nothing to delete on the server, session expired
-			u.setState(errored)
-			return errors.New("Upload session expired")
-		} else if status >= 400 {
-			log.WithFields(log.Fields{
-				"code":     status,
-				"response": resp,
-			}).Errorf(
-				"Error code %d during upload. "+
-					"Onedriver doesn't know how to handle this case yet. "+
-					"Please file a bug report!",
-				status,
-			)
-			u.setState(errored)
-			return errors.New(string(resp))
+		if status >= 400 {
+			err := errors.New(string(resp))
+			u.setState(errored, err)
+			return err
 		}
 	}
-	u.setState(complete)
-	log.WithField("id", u.ID).Info("Upload completed!")
+	u.setState(complete, nil)
+	log.WithField("id", u.ID).Debug("Upload completed!")
 	return nil
 }


### PR DESCRIPTION
This PR adds retries at all phases of the upload process, and will retried failed uploads up to 5 times (instead of just 0-1 times before).