### PR TITLE
Cache upload sessions to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ mount/
 *.test
 *.out
 *.txt
+*.coverage
 
 # do not include binaries, but do include sources
 onedriver

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -173,8 +173,7 @@ func (c *Cache) GetID(id string) *Inode {
 			data := tx.Bucket(METADATA).Get([]byte(id))
 			var err error
 			if data != nil {
-				found = &Inode{}
-				err = json.Unmarshal(data, found)
+				found, err = NewInodeJSON(data)
 			}
 			return err
 		})
@@ -561,7 +560,7 @@ func (c *Cache) SerializeAll() {
 	c.metadata.Range(func(key interface{}, value interface{}) bool {
 		c.db.Batch(func(tx *bolt.Tx) error {
 			id := fmt.Sprint(key)
-			contents, _ := json.Marshal(value.(*Inode))
+			contents := value.(*Inode).AsJSON()
 			b := tx.Bucket(METADATA)
 			b.Put([]byte(id), contents)
 			if id == c.root {

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -173,7 +173,8 @@ func (c *Cache) GetID(id string) *Inode {
 			data := tx.Bucket(METADATA).Get([]byte(id))
 			var err error
 			if data != nil {
-				found, err = NewInodeJSON(data)
+				found = &Inode{}
+				err = json.Unmarshal(data, found)
 			}
 			return err
 		})
@@ -560,7 +561,7 @@ func (c *Cache) SerializeAll() {
 	c.metadata.Range(func(key interface{}, value interface{}) bool {
 		c.db.Batch(func(tx *bolt.Tx) error {
 			id := fmt.Sprint(key)
-			contents := value.(*Inode).AsJSON()
+			contents, _ := json.Marshal(value.(*Inode))
 			b := tx.Bucket(METADATA)
 			b.Put([]byte(id), contents)
 			if id == c.root {

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -90,7 +90,7 @@ func NewCache(auth *graph.Auth, dbpath string) *Cache {
 	cache.root = root.ID()
 	cache.InsertID(cache.root, root)
 
-	cache.uploads = NewUploadManager(2*time.Second, auth)
+	cache.uploads = NewUploadManager(2*time.Second, db, auth)
 
 	if !cache.IsOffline() {
 		// .Trash-UID is used by "gio trash" for user trash, create it if it

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -30,8 +30,11 @@ func TestDeltaMkdir(t *testing.T) {
 	for i := 0; i < retrySeconds; i++ {
 		time.Sleep(time.Second)
 		st, err := os.Stat(filepath.Join(DeltaDir, "first"))
-		if err != nil && st.Mode().IsDir() {
-			return // yay
+		if err == nil {
+			if st.Mode().IsDir() {
+				return // yay
+			}
+			t.Fatalf("%s was not a directory", filepath.Join(DeltaDir, "first"))
 		}
 	}
 	t.Fatalf("%s not found.", filepath.Join(DeltaDir, "first"))

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jstaf/onedriver/fs/graph"
 )
 
-const retrySeconds = 15
+const retrySeconds = 60
 
 // In this test, we create a directory through the API, and wait to see if
 // the cache picks it up post-creation.

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -189,7 +189,7 @@ func TestDeltaContentChangeBoth(t *testing.T) {
 	failOnErr(t, ioutil.WriteFile(fpath, []byte("local"), 0644))
 
 	// file has been changed both remotely and locally
-	time.Sleep(time.Second * retrySeconds)
+	time.Sleep(time.Second * 15)
 	content, err := ioutil.ReadFile(fpath)
 	failOnErr(t, err)
 

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -74,33 +74,33 @@ func NewInode(name string, mode uint32, parent *Inode) *Inode {
 	}
 }
 
-// MarshalJSON converts a DriveItem to JSON for use with local storage. Not used
-// with the API.
-func (i *Inode) MarshalJSON() ([]byte, error) {
+// AsJSON converts a DriveItem to JSON for use with local storage. Not used with
+// the API.
+func (i *Inode) AsJSON() []byte {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()
-	return json.Marshal(SerializeableInode{
+	data, _ := json.Marshal(SerializeableInode{
 		DriveItem: i.DriveItem,
 		Children:  i.children,
 		Subdir:    i.subdir,
 		Mode:      i.mode,
 	})
+	return data
 }
 
-// UnmarshalJSON converts JSON to an Inode when loading from local storage.
-// Not used with the API.
-func (i *Inode) UnmarshalJSON(data []byte) error {
+// NewInodeJSON converts JSON to a *DriveItem when loading from local storage. Not
+// used with the API.
+func NewInodeJSON(data []byte) (*Inode, error) {
 	var raw SerializeableInode
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
+		return nil, err
 	}
-	i.mutex.Lock()
-	defer i.mutex.Unlock()
-	i.DriveItem = raw.DriveItem
-	i.children = raw.Children
-	i.mode = raw.Mode
-	i.subdir = raw.Subdir
-	return nil
+	return &Inode{
+		DriveItem: raw.DriveItem,
+		children:  raw.Children,
+		mode:      raw.Mode,
+		subdir:    raw.Subdir,
+	}, nil
 }
 
 // NewInodeDriveItem creates a new DriveItem from an Inode

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -75,7 +75,8 @@ func NewInode(name string, mode uint32, parent *Inode) *Inode {
 }
 
 // AsJSON converts a DriveItem to JSON for use with local storage. Not used with
-// the API.
+// the API. FIXME: If implemented as MarshalJSON, this will break delta syncs
+// for business accounts. Don't ask me why.
 func (i *Inode) AsJSON() []byte {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()
@@ -89,7 +90,8 @@ func (i *Inode) AsJSON() []byte {
 }
 
 // NewInodeJSON converts JSON to a *DriveItem when loading from local storage. Not
-// used with the API.
+// used with the API. FIXME: If implemented as UnmarshalJSON, this will break
+// delta syncs for business accounts. Don't ask me why.
 func NewInodeJSON(data []byte) (*Inode, error) {
 	var raw SerializeableInode
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	// create paging test files before the delta thread is created
 	os.Mkdir(filepath.Join(TestDir, "paging"), 0755)
-	createPagingTestFiles()
+	//createPagingTestFiles()
 	go fsCache.DeltaLoop(5 * time.Second)
 
 	// not created by default on onedrive for business

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -80,7 +80,7 @@ func TestMain(m *testing.M) {
 
 	// create paging test files before the delta thread is created
 	os.Mkdir(filepath.Join(TestDir, "paging"), 0755)
-	//createPagingTestFiles()
+	createPagingTestFiles()
 	go fsCache.DeltaLoop(5 * time.Second)
 
 	// not created by default on onedrive for business

--- a/fs/upload_manager.go
+++ b/fs/upload_manager.go
@@ -134,7 +134,10 @@ func (u *UploadManager) finishUpload(id string) {
 		session.cancel(u.auth)
 	}
 	u.db.Update(func(tx *bolt.Tx) error {
-		return tx.Bucket(UPLOADS).Delete([]byte(id))
+		if b := tx.Bucket(UPLOADS); b != nil {
+			b.Delete([]byte(id))
+		}
+		return nil
 	})
 	delete(u.sessions, id)
 }

--- a/fs/upload_manager.go
+++ b/fs/upload_manager.go
@@ -1,11 +1,17 @@
 package fs
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/jstaf/onedriver/fs/graph"
 	log "github.com/sirupsen/logrus"
+	bolt "go.etcd.io/bbolt"
 )
+
+// UPLOADS is just a constant to avoid typos in bucket names when referenced
+// elsewhere
+var UPLOADS = []byte("uploads")
 
 // UploadManager is used to manage and retry uploads.
 type UploadManager struct {
@@ -13,16 +19,34 @@ type UploadManager struct {
 	deletionQueue chan string
 	sessions      map[string]*UploadSession
 	auth          *graph.Auth
+	db            *bolt.DB
 }
 
 // NewUploadManager creates a new queue/thread for uploads
-func NewUploadManager(duration time.Duration, auth *graph.Auth) *UploadManager {
+func NewUploadManager(duration time.Duration, db *bolt.DB, auth *graph.Auth) *UploadManager {
 	manager := UploadManager{
 		queue:         make(chan *UploadSession),
 		deletionQueue: make(chan string),
 		sessions:      make(map[string]*UploadSession),
 		auth:          auth,
+		db:            db,
 	}
+	db.View(func(tx *bolt.Tx) error {
+		// Add any incomplete sessions from disk - any sessions here were never
+		// finished. The most likely cause of this is that the user shut off
+		// their computer or closed the program after starting the upload.
+		b := tx.Bucket(UPLOADS)
+		return b.ForEach(func(key []byte, val []byte) error {
+			session := &UploadSession{}
+			err := json.Unmarshal(val, session)
+			if err != nil {
+				return err
+			}
+			session.cancel(auth) // uploads are currently non-resumable
+			manager.sessions[session.ID] = session
+			return nil
+		})
+	})
 	go manager.uploadLoop(duration)
 	return &manager
 }
@@ -37,14 +61,17 @@ func (u *UploadManager) uploadLoop(duration time.Duration) {
 			if old, exists := u.sessions[session.ID]; exists {
 				old.cancel(u.auth)
 			}
+			u.db.Update(func(tx *bolt.Tx) error {
+				// persist to disk in case the user shuts off their computer or
+				// kills onedriver prematurely
+				contents, _ := json.Marshal(session)
+				b, _ := tx.CreateBucketIfNotExists(UPLOADS)
+				return b.Put([]byte(session.ID), contents)
+			})
 			u.sessions[session.ID] = session
 
 		case cancelID := <-u.deletionQueue: // remove uploads for deleted items
-			session, exists := u.sessions[cancelID]
-			if exists {
-				session.cancel(u.auth)
-				delete(u.sessions, cancelID)
-			}
+			u.finishUpload(cancelID)
 
 		case <-ticker.C: // periodically start uploads, or remove them if done/failed
 			for _, session := range u.sessions {
@@ -62,8 +89,7 @@ func (u *UploadManager) uploadLoop(duration time.Duration) {
 							"Upload session failed too many times, cancelling session. " +
 								"This is a bug - please file a bug report!",
 						)
-						session.cancel(u.auth)
-						delete(u.sessions, session.ID)
+						u.finishUpload(session.ID)
 					}
 
 					log.WithFields(log.Fields{
@@ -73,7 +99,7 @@ func (u *UploadManager) uploadLoop(duration time.Duration) {
 					session.cancel(u.auth) // cancel large sessions
 					session.setState(notStarted, nil)
 				case complete:
-					delete(u.sessions, session.ID)
+					u.finishUpload(session.ID)
 				}
 			}
 		}
@@ -92,4 +118,17 @@ func (u *UploadManager) QueueUpload(inode *Inode) error {
 // CancelUpload is used to kill any pending uploads for a session
 func (u *UploadManager) CancelUpload(id string) {
 	u.deletionQueue <- id
+}
+
+// finishUpload is an internal method that gets called when a session is
+// completed. It cancels the session if one was in progress, and then deletes
+// it from both memory and disk.
+func (u *UploadManager) finishUpload(id string) {
+	if session, exists := u.sessions[id]; exists {
+		session.cancel(u.auth)
+	}
+	u.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(UPLOADS).Delete([]byte(id))
+	})
+	delete(u.sessions, id)
 }

--- a/fs/upload_manager_test.go
+++ b/fs/upload_manager_test.go
@@ -59,14 +59,13 @@ func TestUploadDiskSerialization(t *testing.T) {
 		return b.Put([]byte(session.ID), payload)
 	})
 
-	manager := NewUploadManager(time.Second, db, auth)
-	if _, exists := manager.sessions[session.ID]; !exists {
-		t.Fatal("Could not find session after unmarshaling from disk.")
-	}
-
-	time.Sleep(5 * time.Second)
+	NewUploadManager(time.Second, db, auth)
+	time.Sleep(10 * time.Second)
 	driveItem, err = graph.GetItemPath("/onedriver_tests/upload_to_disk.txt", auth)
 	if err != nil || driveItem == nil {
 		t.Fatal("Could not find uploaded file after unserializing from disk and resuming upload.")
+	}
+	if driveItem.Size == 0 {
+		t.Fatal("Size was 0 - the upload was never completed.")
 	}
 }

--- a/fs/upload_manager_test.go
+++ b/fs/upload_manager_test.go
@@ -1,0 +1,72 @@
+package fs
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jstaf/onedriver/fs/graph"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// Test that new uploads are written to disk to support resuming them later if
+// the user shuts down their computer.
+func TestUploadDiskSerialization(t *testing.T) {
+	t.Parallel()
+	// write a file and get its id
+	failOnErr(t, ioutil.WriteFile(filepath.Join(TestDir, "upload_to_disk.txt"), []byte("cheesecake"), 0644))
+	inode, err := fsCache.GetPath("/onedriver_tests/upload_to_disk.txt", nil)
+	failOnErr(t, err)
+
+	// we can find the in-progress upload because there is a several second
+	// delay on new uploads
+	session := UploadSession{}
+	failOnErr(t, fsCache.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(UPLOADS)
+		if b == nil {
+			return errors.New("uploads bucket did not exist")
+		}
+		diskSession := b.Get([]byte(inode.ID()))
+		if diskSession == nil {
+			return errors.New("Item to upload not found on disk")
+		}
+		return json.Unmarshal(diskSession, &session)
+	}))
+
+	// kill the session before it gets uploaded
+	fsCache.uploads.CancelUpload(session.ID)
+
+	// confirm that the file didn't get uploaded yet (just in case!)
+	driveItem, err := graph.GetItemPath("/onedriver_tests/upload_to_disk.txt", auth)
+	if err == nil || driveItem != nil {
+		if driveItem.Size > 0 {
+			t.Fatal("This test should be rewritten, the file was uploaded before " +
+				"the upload could be canceled.")
+		}
+	}
+
+	// now we create a new UploadManager from scratch, with the file injected
+	// into its db and confirm that the file gets uploaded
+	db, err := bolt.Open("test_upload_disk_serialization.db", 0644, nil)
+	failOnErr(t, err)
+	db.Update(func(tx *bolt.Tx) error {
+		b, _ := tx.CreateBucket(UPLOADS)
+		payload, _ := json.Marshal(&session)
+		return b.Put([]byte(session.ID), payload)
+	})
+
+	manager := NewUploadManager(time.Second, db, auth)
+	if _, exists := manager.sessions[session.ID]; !exists {
+		t.Fatal("Could not find session after unmarshaling from disk.")
+	}
+
+	time.Sleep(5 * time.Second)
+	driveItem, err = graph.GetItemPath("/onedriver_tests/upload_to_disk.txt", auth)
+	if err != nil || driveItem == nil {
+		t.Fatal("Could not find uploaded file after unserializing from disk and resuming upload.")
+	}
+}

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -47,6 +47,15 @@ type UploadSession struct {
 	error // embedded error tracks errors that killed an upload
 }
 
+// MarshalJSON implements a custom JSON marshaler to avoid race conditions
+func (u *UploadSession) MarshalJSON() ([]byte, error) {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+
+	type SerializeableUploadSession UploadSession
+	return json.Marshal((*SerializeableUploadSession)(u))
+}
+
 // UploadSessionPost is the initial post used to create an upload session
 type UploadSessionPost struct {
 	Name             string `json:"name,omitempty"`

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -243,13 +243,15 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 				"id":      u.ID,
 				"chunk":   i,
 				"nchunks": nchunks,
+				"status":  status,
 			}).Errorf("The OneDrive server is having issues, retrying chunk upload in %ds.", backoff)
 			time.Sleep(time.Duration(backoff) * time.Second)
 			_, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
 			if err != nil { // a serious, non 4xx/5xx error
 				log.WithFields(log.Fields{
-					"id":  u.ID,
-					"err": err,
+					"id":     u.ID,
+					"err":    err,
+					"status": status,
 				}).Error("Failed while retrying chunk upload after server-side error.")
 				u.setState(errored, err)
 				return err


### PR DESCRIPTION
Now if a user powers off their computer while uploading files, onedriver should recover the upload and complete it successfully.