### PR TITLE
Verify uploads against content checksums

### DIFF
--- a/curl-graph.sh
+++ b/curl-graph.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
 TOKEN=$(jq -r .access_token $1)
-curl -s -H "Authorization: bearer $TOKEN" "https://graph.microsoft.com/v1.0$2"
+ENDPOINT=$2
+shift 2
+
+curl -s -H "Authorization: bearer $TOKEN" $@ "https://graph.microsoft.com/v1.0$ENDPOINT"
+

--- a/fs/delta.go
+++ b/fs/delta.go
@@ -74,7 +74,7 @@ func (c *Cache) DeltaLoop(interval time.Duration) {
 			c.Unlock()
 
 			c.db.Update(func(tx *bolt.Tx) error {
-				return tx.Bucket(DELTA).Put([]byte("deltaLink"), []byte(c.deltaLink))
+				return tx.Bucket(bucketDelta).Put([]byte("deltaLink"), []byte(c.deltaLink))
 			})
 
 			// wait until next interval

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/jstaf/onedriver/fs/graph"
 )
 
-const retrySeconds = 60
-
 // In this test, we create a directory through the API, and wait to see if
 // the cache picks it up post-creation.
 func TestDeltaMkdir(t *testing.T) {

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -184,6 +184,7 @@ func TestDeltaContentChangeBoth(t *testing.T) {
 	failOnErr(t, err)
 	newContent := []byte("remote")
 	inode.data = &newContent
+	inode.DriveItem.Size = uint64(len(newContent))
 	if fsCache.DriveType() == "personal" {
 		inode.DriveItem.File.Hashes.SHA1Hash = SHA1Hash(&newContent)
 	} else {
@@ -191,7 +192,7 @@ func TestDeltaContentChangeBoth(t *testing.T) {
 	}
 	session, err := NewUploadSession(inode, auth)
 	failOnErr(t, err)
-	session.Upload(auth) //FIXME fails test if error is checked
+	failOnErr(t, session.Upload(auth))
 
 	// now change it locally
 	failOnErr(t, ioutil.WriteFile(fpath, []byte("local"), 0644))

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -140,6 +140,11 @@ func TestDeltaContentChangeRemote(t *testing.T) {
 	newContent := []byte("because it has been changed remotely!")
 	inode.DriveItem.Size = uint64(len(newContent))
 	inode.data = &newContent
+	if fsCache.DriveType() == "personal" {
+		inode.DriveItem.File.Hashes.SHA1Hash = SHA1Hash(&newContent)
+	} else {
+		inode.DriveItem.File.Hashes.QuickXorHash = QuickXORHash(&newContent)
+	}
 	session, err := NewUploadSession(inode, auth)
 	failOnErr(t, err)
 	failOnErr(t, session.Upload(auth))
@@ -179,9 +184,14 @@ func TestDeltaContentChangeBoth(t *testing.T) {
 	failOnErr(t, err)
 	newContent := []byte("remote")
 	inode.data = &newContent
+	if fsCache.DriveType() == "personal" {
+		inode.DriveItem.File.Hashes.SHA1Hash = SHA1Hash(&newContent)
+	} else {
+		inode.DriveItem.File.Hashes.QuickXorHash = QuickXORHash(&newContent)
+	}
 	session, err := NewUploadSession(inode, auth)
 	failOnErr(t, err)
-	failOnErr(t, session.Upload(auth))
+	session.Upload(auth) //FIXME fails test if error is checked
 
 	// now change it locally
 	failOnErr(t, ioutil.WriteFile(fpath, []byte("local"), 0644))

--- a/fs/hashes.go
+++ b/fs/hashes.go
@@ -4,13 +4,15 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/rclone/rclone/backend/onedrive/quickxorhash"
 )
 
 // SHA1Hash returns the SHA1 hash of some data as a string
 func SHA1Hash(data *[]byte) string {
-	return fmt.Sprintf("%x", sha1.Sum(*data))
+	// the onedrive API returns SHA1 hashes in all caps, so we do too
+	return strings.ToUpper(fmt.Sprintf("%x", sha1.Sum(*data)))
 }
 
 // QuickXORHash computes the Microsoft-specific QuickXORHash. Reusing rclone's

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -35,6 +35,14 @@ var fsCache *Cache // used to inject bad content into the fs for some tests
 // avoid having to repeatedly recreate auth_tokens.json and juggle multiple auth
 // sessions.
 func TestMain(m *testing.M) {
+	// determine if we're running a single test in vscode or something
+	var singleTest bool
+	for _, arg := range os.Args {
+		if strings.Contains(arg, "-test.run=^(") {
+			singleTest = true
+		}
+	}
+
 	os.Chdir("..")
 	// attempt to unmount regardless of what happens (in case previous tests
 	// failed and didn't clean themselves up)
@@ -80,8 +88,10 @@ func TestMain(m *testing.M) {
 	os.Mkdir(DeltaDir, 0755)
 
 	// create paging test files before the delta thread is created
-	os.Mkdir(filepath.Join(TestDir, "paging"), 0755)
-	createPagingTestFiles()
+	if !singleTest {
+		os.Mkdir(filepath.Join(TestDir, "paging"), 0755)
+		createPagingTestFiles()
+	}
 	go fsCache.DeltaLoop(5 * time.Second)
 
 	// not created by default on onedrive for business

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 	// determine if we're running a single test in vscode or something
 	var singleTest bool
 	for _, arg := range os.Args {
-		if strings.Contains(arg, "-test.run=^(") {
+		if strings.Contains(arg, "-test.run") {
 			singleTest = true
 		}
 	}

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	mountLoc = "mount"
-	TestDir  = mountLoc + "/onedriver_tests"
-	DeltaDir = TestDir + "/delta"
+	mountLoc     = "mount"
+	TestDir      = mountLoc + "/onedriver_tests"
+	DeltaDir     = TestDir + "/delta"
+	retrySeconds = 60
 )
 
 var auth *graph.Auth

--- a/fs/upload_manager_test.go
+++ b/fs/upload_manager_test.go
@@ -72,7 +72,7 @@ func TestUploadDiskSerialization(t *testing.T) {
 
 // There are apparently some edge cases where an upload can remain 0 bytes, even
 // after a successful upload. We need to monitor for these cases and mark these
-// as failed.
+// as failed so they can be retried.
 func TestUploadZeroSizeRetry(t *testing.T) {
 	t.Parallel()
 

--- a/fs/upload_manager_test.go
+++ b/fs/upload_manager_test.go
@@ -26,7 +26,7 @@ func TestUploadDiskSerialization(t *testing.T) {
 	// delay on new uploads
 	session := UploadSession{}
 	failOnErr(t, fsCache.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket(UPLOADS)
+		b := tx.Bucket(bucketUploads)
 		if b == nil {
 			return errors.New("uploads bucket did not exist")
 		}
@@ -54,7 +54,7 @@ func TestUploadDiskSerialization(t *testing.T) {
 	db, err := bolt.Open("test_upload_disk_serialization.db", 0644, nil)
 	failOnErr(t, err)
 	db.Update(func(tx *bolt.Tx) error {
-		b, _ := tx.CreateBucket(UPLOADS)
+		b, _ := tx.CreateBucket(bucketUploads)
 		payload, _ := json.Marshal(&session)
 		return b.Put([]byte(session.ID), payload)
 	})
@@ -67,46 +67,5 @@ func TestUploadDiskSerialization(t *testing.T) {
 	}
 	if driveItem.Size == 0 {
 		t.Fatal("Size was 0 - the upload was never completed.")
-	}
-}
-
-// There are apparently some edge cases where an upload can remain 0 bytes, even
-// after a successful upload. We need to monitor for these cases and mark these
-// as failed so they can be retried. TODO: this test sucks and should be rewritten
-func TestUploadZeroSizeRetry(t *testing.T) {
-	t.Parallel()
-
-	// write a file and get its id
-	contents := []byte("fudge")
-	failOnErr(t, ioutil.WriteFile(filepath.Join(TestDir, "upload_fail_empty.txt"), contents, 0644))
-	inode, err := fsCache.GetPath("/onedriver_tests/upload_fail_empty.txt", nil)
-	failOnErr(t, err)
-
-	// kill the session before it gets uploaded
-	fsCache.uploads.CancelUpload(inode.ID())
-
-	// verify its size is still 0 server-side
-	remote, err := graph.GetItem(inode.ID(), auth)
-	failOnErr(t, err)
-	if remote == nil {
-		t.Fatal("A placeholder file was never uploaded for upload_fail_empty.txt." +
-			"This is a bug in this test.")
-	}
-	if remote.Size > 0 {
-		t.Fatal("The file finished its upload before it could be canceled. " +
-			"This is a bug in this test.")
-	}
-
-	// create a new session, check the remote checksums the way the app would, then
-	// upload manually and re-check
-	inode.data = &contents
-	session, err := NewUploadSession(inode, auth)
-	if session.verifyRemoteChecksum(auth) {
-		t.Fatal("Checksums should not match before reupload.")
-	}
-
-	failOnErr(t, session.Upload(auth))
-	if !session.verifyRemoteChecksum(auth) {
-		t.Fatal("Checksums must match post upload.")
 	}
 }

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -22,10 +22,10 @@ const chunkSize uint64 = 10 * 1024 * 1024
 
 // upload states
 const (
-	notStarted = iota
-	started
-	complete
-	errored
+	uploadNotStarted = iota
+	uploadStarted
+	uploadComplete
+	uploadErrored
 )
 
 // UploadSession contains a snapshot of the file we're uploading. We have to
@@ -40,7 +40,6 @@ type UploadSession struct {
 	Size               uint64    `json:"size,omitempty"`
 	Data               []byte    `json:"data,omitempty"`
 	Checksum           string    `json:"checksum,omitempty"`
-	ChecksumType       string    `json:"checksumType,omitempty"`
 	ModTime            time.Time `json:"modTime,omitempty"`
 	retries            int
 
@@ -84,11 +83,14 @@ func (u *UploadSession) getState() int {
 	return u.state
 }
 
-func (u *UploadSession) setState(state int, err error) {
+// setState is just a helper method to set the UploadSession state and make error checking
+// a little more straightforwards.
+func (u *UploadSession) setState(state int, err error) error {
 	u.mutex.Lock()
 	u.state = state
 	u.error = err
 	u.mutex.Unlock()
+	return err
 }
 
 // NewUploadSession wraps an upload of a file into an UploadSession struct
@@ -118,22 +120,20 @@ func NewUploadSession(inode *Inode, auth *graph.Auth) (*UploadSession, error) {
 			"id":   inode.DriveItem.ID,
 			"name": inode.DriveItem.Name,
 		}).Error("Tried to dereference a nil pointer.")
-		return nil, errors.New("Inode data was nil")
+		return nil, errors.New("inode data was nil")
 	}
 	copy(session.Data, *inode.data)
 
 	if inode.DriveItem.File.Hashes.SHA1Hash != "" {
 		session.Checksum = inode.DriveItem.File.Hashes.SHA1Hash
-		session.ChecksumType = "SHA1Hash"
 	} else if inode.DriveItem.File.Hashes.QuickXorHash != "" {
 		session.Checksum = inode.DriveItem.File.Hashes.QuickXorHash
-		session.ChecksumType = "QuickXorHash"
 	} else {
 		log.WithFields(log.Fields{
 			"id":   inode.DriveItem.ID,
 			"name": inode.DriveItem.Name,
-		}).Error("Both inode checksums were nil!")
-		return nil, errors.New("Both inode checksums were nil")
+		}).Error("both inode checksums were nil!")
+		return nil, errors.New("both inode checksums were nil")
 	}
 	return &session, nil
 }
@@ -143,7 +143,7 @@ func (u *UploadSession) cancel(auth *graph.Auth) {
 	// is it an actual API upload session?
 	if u.isLargeSession() {
 		state := u.getState()
-		if state == started || state == errored {
+		if state == uploadStarted || state == uploadErrored {
 			// dont care about result, this is purely us being polite to the server
 			go graph.Delete(u.UploadURL, auth)
 		}
@@ -157,7 +157,7 @@ func (u *UploadSession) cancel(auth *graph.Auth) {
 // the HTTP request at all).
 func (u *UploadSession) uploadChunk(auth *graph.Auth, offset uint64) ([]byte, int, error) {
 	if u.UploadURL == "" {
-		return nil, -1, errors.New("uploadSession UploadURL cannot be empty")
+		return nil, -1, errors.New("UploadSession UploadURL cannot be empty")
 	}
 
 	// how much of the file are we going to upload?
@@ -196,18 +196,16 @@ func (u *UploadSession) uploadChunk(auth *graph.Auth, offset uint64) ([]byte, in
 }
 
 // verifyRemoteChecksum confirms that the newly-uploaded remote file matches the
-// local checksum. Returns false if there is a mismatch. TODO: remove in favor
-// of simply checking the response from the server after upload of the final
-// chunk (or only chunk)
-func (u *UploadSession) verifyRemoteChecksum(auth *graph.Auth) bool {
-	remote, err := graph.GetItem(u.ID, auth)
-	if err != nil {
-		return false
+// local checksum. Returns false if there is a mismatch.
+func (u *UploadSession) verifyRemoteChecksum(response []byte) error {
+	remote := graph.DriveItem{}
+	if err := json.Unmarshal(response, &remote); err != nil {
+		return u.setState(uploadErrored, err)
 	}
-	if u.ChecksumType == "SHA1Hash" {
-		return remote.File.Hashes.SHA1Hash == u.Checksum
+	if remote.File.Hashes.SHA1Hash != u.Checksum && remote.File.Hashes.QuickXorHash != u.Checksum {
+		return u.setState(uploadErrored, errors.New("remote checksum did not match"))
 	}
-	return remote.File.Hashes.QuickXorHash == u.Checksum
+	return u.setState(uploadComplete, nil)
 }
 
 // Upload copies the file's contents to the server. Should only be called as a
@@ -215,10 +213,10 @@ func (u *UploadSession) verifyRemoteChecksum(auth *graph.Auth) bool {
 // field contains errors to be handled if called as a goroutine.
 func (u *UploadSession) Upload(auth *graph.Auth) error {
 	log.WithField("id", u.ID).Debug("Uploading file.")
-	u.setState(started, nil)
+	u.setState(uploadStarted, nil)
 	if !u.isLargeSession() {
 		// small files handled in this block
-		_, err := graph.Put(
+		remote, err := graph.Put(
 			fmt.Sprintf("/me/drive/items/%s/content", u.ID),
 			auth,
 			bytes.NewReader(u.Data),
@@ -226,20 +224,16 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 		if err != nil && strings.Contains(err.Error(), "resourceModified") {
 			// retry the request after a second, likely the server is having issues
 			time.Sleep(time.Second)
-			_, err = graph.Put(
+			remote, err = graph.Put(
 				fmt.Sprintf("/me/drive/items/%s/content", u.ID),
 				auth,
 				bytes.NewReader(u.Data),
 			)
 		}
-
-		if err != nil || !u.verifyRemoteChecksum(auth) {
-			// upload has failed
-			u.setState(errored, err)
-		} else {
-			u.setState(complete, nil)
+		if err != nil {
+			return u.setState(uploadErrored, err)
 		}
-		return err
+		return u.verifyRemoteChecksum(remote)
 	}
 
 	// must create a formal upload session with the API for large sessions
@@ -255,24 +249,23 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 		bytes.NewReader(sessionPostData),
 	)
 	if err != nil {
-		u.setState(errored, err)
-		return err
+		return u.setState(uploadErrored, err)
 	}
 	// populate UploadURL/expiration - we unmarshal into a fresh session here
 	// just in case the API does something silly at a later date and overwrites
 	// a field it shouldn't.
 	tmp := UploadSession{}
 	if err = json.Unmarshal(resp, &tmp); err != nil {
-		u.setState(errored, err)
-		return err
+		return u.setState(uploadErrored, err)
 	}
 	u.UploadURL = tmp.UploadURL
 	u.ExpirationDateTime = tmp.ExpirationDateTime
 
 	// api upload session created successfully, now do actual content upload
+	var status int
 	nchunks := int(math.Ceil(float64(u.Size) / float64(chunkSize)))
 	for i := 0; i < nchunks; i++ {
-		resp, status, err := u.uploadChunk(auth, uint64(i)*chunkSize)
+		resp, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
 		if err != nil {
 			log.WithFields(log.Fields{
 				"id":      u.ID,
@@ -280,8 +273,7 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 				"nchunks": nchunks,
 				"err":     err,
 			}).Error("Error during chunk upload.")
-			u.setState(errored, err)
-			return err
+			return u.setState(uploadErrored, err)
 		}
 
 		// retry server-side failures with an exponential back-off strategy. Will not
@@ -294,32 +286,21 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 				"status":  status,
 			}).Errorf("The OneDrive server is having issues, retrying chunk upload in %ds.", backoff)
 			time.Sleep(time.Duration(backoff) * time.Second)
-			_, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
+			resp, status, err = u.uploadChunk(auth, uint64(i)*chunkSize)
 			if err != nil { // a serious, non 4xx/5xx error
 				log.WithFields(log.Fields{
 					"id":     u.ID,
 					"err":    err,
 					"status": status,
 				}).Error("Failed while retrying chunk upload after server-side error.")
-				u.setState(errored, err)
-				return err
+				return u.setState(uploadErrored, err)
 			}
 		}
 
 		// handle client-side errors
 		if status >= 400 {
-			err := errors.New(string(resp))
-			u.setState(errored, err)
-			return err
+			return u.setState(uploadErrored, errors.New(string(resp)))
 		}
 	}
-
-	if !u.verifyRemoteChecksum(auth) {
-		err = errors.New("checksums did not match")
-		u.setState(errored, err)
-		return err
-	}
-	u.setState(complete, nil)
-	log.WithField("id", u.ID).Debug("Upload completed!")
-	return nil
+	return u.verifyRemoteChecksum(resp)
 }


### PR DESCRIPTION
This PR ensures that the server-side checksum returned following an upload matches the local content's checksum (or the upload is retried).