### PR TITLE
Lockfile fixes for LibreOffice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: turnstyle
     strategy:
+      fail-fast: false
       matrix:
         account_type:
           - personal

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -242,12 +241,6 @@ func (c *Cache) DeleteID(id string) {
 	c.uploads.CancelUpload(id)
 }
 
-// only used for parsing
-type driveChildren struct {
-	Children []*Inode `json:"value"`
-	NextLink string   `json:"@odata.nextLink"`
-}
-
 // GetChild fetches a named child of an item. Wraps GetChildrenID.
 func (c *Cache) GetChild(id string, name string, auth *graph.Auth) (*Inode, error) {
 	children, err := c.GetChildrenID(id, auth)
@@ -304,35 +297,26 @@ func (c *Cache) GetChildrenID(id string, auth *graph.Auth) (map[string]*Inode, e
 	inode.mutex.RUnlock()
 
 	// We haven't fetched the children for this item yet, get them from the server.
-	fetched := make([]*Inode, 0)
-	for pollURL := graph.ChildrenPathID(id); pollURL != ""; {
-		body, err := graph.Get(pollURL, auth)
-		if err != nil {
-			if graph.IsOffline(err) {
-				log.WithFields(log.Fields{
-					"id": id,
-				}).Warn("We are offline, and no children found in cache. Pretending there are no children.")
-				return children, nil
-			}
-			// something else happened besides being offline
+	fetched, err := graph.GetItemChildren(id, auth)
+	if err != nil {
+		if graph.IsOffline(err) {
 			log.WithFields(log.Fields{
-				"err": err,
-			}).Error("Error while fetching children.")
-			return nil, err
+				"id": id,
+			}).Warn("We are offline, and no children found in cache. Pretending there are no children.")
+			return children, nil
 		}
-		var pollResult driveChildren
-		json.Unmarshal(body, &pollResult)
-
-		// there can be multiple pages of 200 items each (default).
-		// continue to next interation if we have an @odata.nextLink value
-		fetched = append(fetched, pollResult.Children...)
-		pollURL = strings.TrimPrefix(pollResult.NextLink, graph.GraphURL)
+		// something else happened besides being offline
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Error("Error while fetching children.")
+		return nil, err
 	}
 
 	inode.mutex.Lock()
 	inode.children = make([]string, 0)
-	for _, child := range fetched {
+	for _, item := range fetched {
 		// we will always have an id after fetching from the server
+		child := NewInodeDriveItem(item)
 		child.cache = c
 		c.metadata.Store(child.DriveItem.ID, child)
 

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -129,25 +129,6 @@ func (c *Cache) IsOffline() bool {
 	return c.offline
 }
 
-// DriveType lazily fetches the OneDrive drivetype
-func (c *Cache) DriveType() string {
-	c.RLock()
-	driveType := c.driveType
-	c.RUnlock()
-
-	if driveType == "" {
-		drive, err := graph.GetDrive(c.GetAuth())
-		if err == nil {
-			c.Lock()
-			c.driveType = drive.DriveType
-			c.Unlock()
-			return drive.DriveType
-		}
-		log.Error("Drivetype was empty and could not be fetched!")
-	}
-	return driveType
-}
-
 func leadingSlash(path string) string {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path

--- a/fs/delta.go
+++ b/fs/delta.go
@@ -218,9 +218,9 @@ func (c *Cache) applyDelta(delta *Inode) error {
 	//
 	// Do not sync if the file size is 0, as this is likely a file in the
 	// progress of being uploaded (also, no need to sync empty files).
-	if delta.ModTime() > local.ModTime() && delta.Size() > 0 {
+	if delta.ModTime() > local.ModTime() && !delta.IsDir() && delta.Size() > 0 {
+		sameContent := false
 		local.mutex.RLock()
-		var sameContent bool
 		if delta.DriveItem.Parent.DriveType == graph.DriveTypePersonal {
 			sameContent = local.VerifyChecksum(delta.File.Hashes.SHA1Hash)
 		} else {

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -17,7 +17,7 @@ import (
 func (i *Inode) setContent(newContent []byte) {
 	i.DriveItem.Size = uint64(len(newContent))
 	i.data = &newContent
-	if fsCache.DriveType() == "personal" {
+	if fsCache.DriveType() == graph.DriveTypePersonal {
 		i.DriveItem.File.Hashes.SHA1Hash = graph.SHA1Hash(&newContent)
 	} else {
 		i.DriveItem.File.Hashes.QuickXorHash = graph.QuickXORHash(&newContent)

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -13,6 +13,17 @@ import (
 	"github.com/jstaf/onedriver/fs/graph"
 )
 
+// a helper function for use with tests
+func (i *Inode) setContent(newContent []byte) {
+	i.DriveItem.Size = uint64(len(newContent))
+	i.data = &newContent
+	if fsCache.DriveType() == "personal" {
+		i.DriveItem.File.Hashes.SHA1Hash = graph.SHA1Hash(&newContent)
+	} else {
+		i.DriveItem.File.Hashes.QuickXorHash = graph.QuickXORHash(&newContent)
+	}
+}
+
 // In this test, we create a directory through the API, and wait to see if
 // the cache picks it up post-creation.
 func TestDeltaMkdir(t *testing.T) {
@@ -138,13 +149,7 @@ func TestDeltaContentChangeRemote(t *testing.T) {
 	inode := NewInodeDriveItem(item)
 	failOnErr(t, err)
 	newContent := []byte("because it has been changed remotely!")
-	inode.DriveItem.Size = uint64(len(newContent))
-	inode.data = &newContent
-	if fsCache.DriveType() == "personal" {
-		inode.DriveItem.File.Hashes.SHA1Hash = SHA1Hash(&newContent)
-	} else {
-		inode.DriveItem.File.Hashes.QuickXorHash = QuickXORHash(&newContent)
-	}
+	inode.setContent(newContent)
 	session, err := NewUploadSession(inode, auth)
 	failOnErr(t, err)
 	failOnErr(t, session.Upload(auth))
@@ -183,13 +188,7 @@ func TestDeltaContentChangeBoth(t *testing.T) {
 	inode := NewInodeDriveItem(item)
 	failOnErr(t, err)
 	newContent := []byte("remote")
-	inode.data = &newContent
-	inode.DriveItem.Size = uint64(len(newContent))
-	if fsCache.DriveType() == "personal" {
-		inode.DriveItem.File.Hashes.SHA1Hash = SHA1Hash(&newContent)
-	} else {
-		inode.DriveItem.File.Hashes.QuickXorHash = QuickXORHash(&newContent)
-	}
+	inode.setContent(newContent)
 	session, err := NewUploadSession(inode, auth)
 	failOnErr(t, err)
 	failOnErr(t, session.Upload(auth))

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -316,13 +316,14 @@ func TestDeltaNoModTimeUpdate(t *testing.T) {
 	mtimeOriginal := finfo.ModTime()
 
 	time.Sleep(15 * time.Second)
+
 	finfo, err = os.Stat(fname)
 	failOnErr(t, err)
 	mtimeNew := finfo.ModTime()
 	if !mtimeNew.Equal(mtimeOriginal) {
 		t.Fatalf(
 			"Modification time was updated even though the file did not change.\n"+
-				"Old mtime: %d, New mtime: %d \n", mtimeOriginal.Unix(), mtimeNew.Unix(),
+				"Old mtime: %d, New mtime: %d\n", mtimeOriginal.Unix(), mtimeNew.Unix(),
 		)
 	}
 }

--- a/fs/delta_test.go
+++ b/fs/delta_test.go
@@ -17,7 +17,7 @@ import (
 func (i *Inode) setContent(newContent []byte) {
 	i.DriveItem.Size = uint64(len(newContent))
 	i.data = &newContent
-	if fsCache.DriveType() == graph.DriveTypePersonal {
+	if i.DriveItem.Parent.DriveType == graph.DriveTypePersonal {
 		i.DriveItem.File.Hashes.SHA1Hash = graph.SHA1Hash(&newContent)
 	} else {
 		i.DriveItem.File.Hashes.QuickXorHash = graph.QuickXORHash(&newContent)

--- a/fs/graph/drive_item.go
+++ b/fs/graph/drive_item.go
@@ -7,13 +7,22 @@ import (
 	"time"
 )
 
-// DriveItemParent describes a DriveItem's parent in the Graph API (just another
-// DriveItem's ID and its path)
+// DriveTypePersonal and friends represent the possible different values for a
+// drive's type when fetched from the API.
+const (
+	DriveTypePersonal   = "personal"
+	DriveTypeBusiness   = "business"
+	DriveTypeSharepoint = "documentLibrary"
+)
+
+// DriveItemParent describes a DriveItem's parent in the Graph API
 // https://docs.microsoft.com/en-us/onedrive/developer/rest-api/resources/itemreference
 type DriveItemParent struct {
 	//TODO Path is technically available, but we shouldn't use it
-	Path string `json:"path,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Path      string `json:"path,omitempty"`
+	ID        string `json:"id,omitempty"`
+	DriveID   string `json:"driveId,omitempty"`
+	DriveType string `json:"driveType,omitempty"` // personal | business | documentLibrary
 }
 
 // Folder is used for parsing only

--- a/fs/graph/graph.go
+++ b/fs/graph/graph.go
@@ -132,7 +132,7 @@ func ResourcePath(path string) string {
 }
 
 // ChildrenPath returns the path to an item's children
-func ChildrenPath(path string) string {
+func childrenPath(path string) string {
 	if path == "/" {
 		return ResourcePath(path) + "/children"
 	}
@@ -140,7 +140,7 @@ func ChildrenPath(path string) string {
 }
 
 // ChildrenPathID returns the API resource path of an item's children
-func ChildrenPathID(id string) string {
+func childrenPathID(id string) string {
 	return "/me/drive/items/" + id + "/children"
 }
 

--- a/fs/graph/graph.go
+++ b/fs/graph/graph.go
@@ -176,7 +176,7 @@ type DriveQuota struct {
 // https://docs.microsoft.com/en-us/onedrive/developer/rest-api/resources/drive
 type Drive struct {
 	ID        string     `json:"id"`
-	DriveType string     `json:"driveType"` // personal or business
+	DriveType string     `json:"driveType"` // personal | business | documentLibrary
 	Quota     DriveQuota `json:"quota,omitempty"`
 }
 

--- a/fs/graph/hashes.go
+++ b/fs/graph/hashes.go
@@ -1,4 +1,4 @@
-package fs
+package graph
 
 import (
 	"crypto/sha1"
@@ -21,4 +21,18 @@ func SHA1Hash(data *[]byte) string {
 func QuickXORHash(data *[]byte) string {
 	hash := quickxorhash.Sum(*data)
 	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// VerifyChecksum checks to see if a DriveItem's checksum matches what it's
+// supposed to be. This is less of a cryptographic check and more of a file
+// integrity check.
+func (d *DriveItem) VerifyChecksum(checksum string) bool {
+	if len(checksum) == 0 {
+		return false
+	}
+	// all checksums are converted to upper to avoid casing issues from whatever
+	// the API decides to return at this point in time.
+	checksum = strings.ToUpper(checksum)
+	return strings.ToUpper(d.File.Hashes.SHA1Hash) == checksum ||
+		strings.ToUpper(d.File.Hashes.QuickXorHash) == checksum
 }

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -441,7 +441,7 @@ func (i *Inode) Fsync(ctx context.Context, f fs.FileHandle, flags uint32) syscal
 
 		// recompute hashes when saving new content
 		i.DriveItem.File = &graph.File{}
-		if i.cache.DriveType() == graph.DriveTypePersonal {
+		if i.DriveItem.Parent.DriveType == graph.DriveTypePersonal {
 			i.DriveItem.File.Hashes.SHA1Hash = graph.SHA1Hash(i.data)
 		} else {
 			i.DriveItem.File.Hashes.QuickXorHash = graph.QuickXORHash(i.data)
@@ -799,11 +799,11 @@ func (i *Inode) Open(ctx context.Context, flags uint32) (fh fs.FileHandle, fuseF
 
 	// try grabbing from disk
 	cache := i.GetCache()
-	driveType := cache.DriveType()
 	if content := cache.GetContent(id); content != nil {
 		// verify content against what we're supposed to have
 		var hashMatch bool
 		i.mutex.RLock()
+		driveType := i.DriveItem.Parent.DriveType
 		if isLocalID(id) && i.DriveItem.File == nil {
 			// only check hashes if the file has been uploaded before, otherwise
 			// we just accept the cached content.

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -274,7 +275,11 @@ func (i *Inode) RemoteID(auth *graph.Auth) (string, error) {
 
 	originalID := i.ID()
 	if isLocalID(originalID) && auth.AccessToken != "" {
-		uploadPath := fmt.Sprintf("/me/drive/items/%s:/%s:/content", i.ParentID(), i.Name())
+		uploadPath := fmt.Sprintf(
+			"/me/drive/items/%s:/%s:/content",
+			i.ParentID(),
+			url.PathEscape(i.Name()),
+		)
 		resp, err := graph.Put(uploadPath, auth, strings.NewReader(""))
 		if err != nil {
 			if strings.Contains(err.Error(), "nameAlreadyExists") {

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -55,8 +55,12 @@ type SerializeableInode struct {
 func NewInode(name string, mode uint32, parent *Inode) *Inode {
 	itemParent := &graph.DriveItemParent{ID: "", Path: ""}
 	if parent != nil {
-		itemParent.ID = parent.ID()
 		itemParent.Path = parent.Path()
+		parent.mutex.RLock()
+		itemParent.ID = parent.DriveItem.ID
+		itemParent.DriveID = parent.DriveItem.Parent.DriveID
+		itemParent.DriveType = parent.DriveItem.Parent.DriveType
+		parent.mutex.RUnlock()
 	}
 
 	var empty []byte

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -202,7 +202,7 @@ func (u *UploadSession) verifyRemoteChecksum(response []byte) error {
 	if err := json.Unmarshal(response, &remote); err != nil {
 		return u.setState(uploadErrored, err)
 	}
-	if remote.File.Hashes.SHA1Hash != u.Checksum && remote.File.Hashes.QuickXorHash != u.Checksum {
+	if !remote.VerifyChecksum(u.Checksum) {
 		return u.setState(uploadErrored, errors.New("remote checksum did not match"))
 	}
 	return u.setState(uploadComplete, nil)


### PR DESCRIPTION
* Filenames are now sanitized on upload to allow otherwise "strange" characters in filenames
* Modification times and cache content is no longer overwritten if the remote checksum matches the local one (ie. if there were no changes)