### PR TITLE
Add catch for generic network failures during token renewal

### DIFF
--- a/fs/graph/graph.go
+++ b/fs/graph/graph.go
@@ -196,5 +196,6 @@ func IsOffline(err error) bool {
 		return false
 	}
 	return strings.Contains(err.Error(), "network is unreachable") ||
-		strings.Contains(err.Error(), "connection refused")
+		strings.Contains(err.Error(), "connection refused") ||
+		strings.Contains(err.Error(), "failure in name resolution")
 }

--- a/fs/graph/oauth2.go
+++ b/fs/graph/oauth2.go
@@ -61,7 +61,7 @@ func (a *Auth) Refresh() {
 
 		var reauth bool
 		if err != nil {
-			if IsOffline(err) {
+			if IsOffline(err) || resp == nil {
 				log.WithFields(log.Fields{
 					"err": err,
 				}).Trace("Network unreachable during token renewal, ignoring.")


### PR DESCRIPTION
Though we already attempt to check for several generic networking related errors, this PR adds a check for the response body being nil that should catch any errors not caused by one of the few networking errors we look for.