### PR TITLE
Fix first-time authentication after update to Microsoft auth APIs

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -418,7 +418,7 @@ func TestStat(t *testing.T) {
 	}
 
 	if !stat.IsDir() {
-		t.Fatal("Mode of /Documents wrong, not detected as directory, got: " + string(stat.Mode()))
+		t.Fatalf("Mode of /Documents wrong, not detected as directory, got: %s", stat.Mode())
 	}
 }
 

--- a/fs/graph/oauth2.go
+++ b/fs/graph/oauth2.go
@@ -154,10 +154,7 @@ func getAuthTokens(authCode string) *Auth {
 			}
 		}
 		log.WithFields(fields).Fatalf(
-			"Failed to retrieve access tokens. Authentication cannot continue. " +
-				"This can be either a client-side error " +
-				"(onedriver isn't authenticating properly) " +
-				"or a server-side outage with Microsoft's authentication services.")
+			"Failed to retrieve access tokens. Authentication cannot continue.")
 	}
 	return &auth
 }

--- a/fs/graph/oauth2.go
+++ b/fs/graph/oauth2.go
@@ -2,10 +2,12 @@ package graph
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -112,6 +114,17 @@ func getAuthURL() string {
 		"&scope=" + url.PathEscape("user.read files.readwrite.all offline_access") +
 		"&response_type=code" +
 		"&redirect_uri=" + authRedirectURL
+}
+
+// parseAuthCode is used to parse the auth code out of the redirect the server gives us
+// after successful authentication
+func parseAuthCode(url string) (string, error) {
+	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_.])+")
+	code := rexp.FindString(url)
+	if len(code) == 0 {
+		return "", errors.New("invalid auth code")
+	}
+	return code[5:], nil
 }
 
 // Exchange an auth code for a set of access tokens

--- a/fs/graph/oauth2_gtk.go
+++ b/fs/graph/oauth2_gtk.go
@@ -25,7 +25,7 @@ func getAuthCode() string {
 	C.free(unsafe.Pointer(cAuthURL))
 	C.free(unsafe.Pointer(cResponse))
 
-	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_])+")
+	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_.])+")
 	code := rexp.FindString(response)
 	if len(code) == 0 {
 		log.Fatal("No validation code returned, or code was invalid. " +

--- a/fs/graph/oauth2_gtk.go
+++ b/fs/graph/oauth2_gtk.go
@@ -10,7 +10,6 @@ package graph
 import "C"
 
 import (
-	"regexp"
 	"unsafe"
 
 	log "github.com/sirupsen/logrus"
@@ -25,11 +24,11 @@ func getAuthCode() string {
 	C.free(unsafe.Pointer(cAuthURL))
 	C.free(unsafe.Pointer(cResponse))
 
-	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_.])+")
-	code := rexp.FindString(response)
-	if len(code) == 0 {
+	code, err := parseAuthCode(response)
+	if err != nil {
+		//TODO create a popup with the auth failure message here instead of a log message
 		log.Fatal("No validation code returned, or code was invalid. " +
 			"Please restart the application and try again.")
 	}
-	return code[5:]
+	return code
 }

--- a/fs/graph/oauth2_headless.go
+++ b/fs/graph/oauth2_headless.go
@@ -4,7 +4,6 @@ package graph
 
 import (
 	"fmt"
-	"regexp"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -15,12 +14,10 @@ func getAuthCode() string {
 		"blank page (after \"Let this app access your info?\"):")
 	var response string
 	fmt.Scanln(&response)
-
-	rexp := regexp.MustCompile("code=([a-zA-Z0-9-_])+")
-	code := rexp.FindString(response)
-	if len(code) == 0 {
+	code, err := parseAuthCode(response)
+	if err != nil {
 		log.Fatal("No validation code returned, or code was invalid. " +
 			"Please restart the application and try again.")
 	}
-	return code[5:]
+	return code
 }

--- a/fs/graph/oauth2_test.go
+++ b/fs/graph/oauth2_test.go
@@ -5,6 +5,26 @@ import (
 	"time"
 )
 
+func TestAuthCodeFormat(t *testing.T) {
+	// arbitrary regext test
+	code, err := parseAuthCode("codecode=asd-965198osATYjfb._knlwoieurow*sdjf")
+	if err != nil || code != "asd-965198osATYjfb._knlwoieurow" {
+		t.Fatal("Auth code parser did not succeed against arbitrary character test.")
+	}
+
+	// faked personal auth code
+	code, err = parseAuthCode("https://login.live.com/oauth20_desktop.srf?code=M.R3_BAY.abcd526-817f-d8e9-590c-1227b45c7be2&lc=4105")
+	if err != nil || code != "M.R3_BAY.abcd526-817f-d8e9-590c-1227b45c7be2" {
+		t.Fatal("Personal auth code did not match expected result.")
+	}
+
+	// faked business auth code
+	code, err = parseAuthCode("https://login.live.com/oauth20_desktop.srf?code=0.BAAA-AeXRPDP_sEe7XktwiDweriowjeirjcDQQvKtFoKktMINkhdEzAAA.AQABAAAAARWERAB2UyzwtQEKR7-rWbgdcBZICdWKCJnfnPJurxUN_QbF3GS6OQqQiK987AbLAv2QykQMIGAz4XCvkO8kB3XC8RYV10qmnmHcMUgo7u5UubpgpR3OW3TVlMSZ-3vxjkcEHlsnVoBqfUFdcj8fYR_mP6w0xkB8MmLG3i5F-JtcaLKfQu13941lsdjkfdh0acjHBGJHVzpBbuiVfzN6vMygFiS2xAQGF668M_l69dXRmG1tq3ZwU6J0-FWYNfK_Ro4YS2m38bcNmZQ8iEolV78t34HKxCYZnl4iqeYF7b7hkTM7ZIcsDBoeZvW1Cu6dIQ7xC4NZGILltOXY5V6A-kcLCZaYuSFW_R8dEM-cqGr_5Gv1GhgfqyXd-2XYNvGda9ok20JrYEmMiezfnyRV-vc7rdtlLOVI_ubzhrjezAvtAApPEj3dJdcmW_0qns_R27pVDlU1xkDagQAquhrftE_sZHbRGvnAsdfaoim1SjcX7QosTELyoWeAczip4MPYqmJ1uVjpWb533vA5WZMyWatiDuNYhnj48SsfEP2zaUQFU55Aj90hEOhOPl77AOu0-zNfAGXeWAQhTPO2rZ0ZgHottFwLoq8aA52sTW-hf7kB0chFUaUvLkxKr1L-Zi7vyCBoArlciFV3zyMxiQ8kjR3vxfwlerjowicmcgqJD-8lxioiwerwlbrlQWyAA&session_state=3fa7b212-7dbb-44e6-bddd-812fwieojw914341")
+	if err != nil || code != "0.BAAA-AeXRPDP_sEe7XktwiDweriowjeirjcDQQvKtFoKktMINkhdEzAAA.AQABAAAAARWERAB2UyzwtQEKR7-rWbgdcBZICdWKCJnfnPJurxUN_QbF3GS6OQqQiK987AbLAv2QykQMIGAz4XCvkO8kB3XC8RYV10qmnmHcMUgo7u5UubpgpR3OW3TVlMSZ-3vxjkcEHlsnVoBqfUFdcj8fYR_mP6w0xkB8MmLG3i5F-JtcaLKfQu13941lsdjkfdh0acjHBGJHVzpBbuiVfzN6vMygFiS2xAQGF668M_l69dXRmG1tq3ZwU6J0-FWYNfK_Ro4YS2m38bcNmZQ8iEolV78t34HKxCYZnl4iqeYF7b7hkTM7ZIcsDBoeZvW1Cu6dIQ7xC4NZGILltOXY5V6A-kcLCZaYuSFW_R8dEM-cqGr_5Gv1GhgfqyXd-2XYNvGda9ok20JrYEmMiezfnyRV-vc7rdtlLOVI_ubzhrjezAvtAApPEj3dJdcmW_0qns_R27pVDlU1xkDagQAquhrftE_sZHbRGvnAsdfaoim1SjcX7QosTELyoWeAczip4MPYqmJ1uVjpWb533vA5WZMyWatiDuNYhnj48SsfEP2zaUQFU55Aj90hEOhOPl77AOu0-zNfAGXeWAQhTPO2rZ0ZgHottFwLoq8aA52sTW-hf7kB0chFUaUvLkxKr1L-Zi7vyCBoArlciFV3zyMxiQ8kjR3vxfwlerjowicmcgqJD-8lxioiwerwlbrlQWyAA" {
+		t.Fatal("Business auth code did not match expected result.")
+	}
+}
+
 func TestAuthFromfile(t *testing.T) {
 	t.Parallel()
 	var auth Auth


### PR DESCRIPTION
Microsoft has changed the format of their access codes used to obtain authentication tokens in a big update last night (this also took out all Microsoft services for several hours). It turns out that they added `.` to the list of characters that can be part of an auth code. This PR ensures that we can perform first-time auth using the new format.