### PR TITLE
[Proposal] Re-enable auto restart

### DIFF
--- a/resources/onedriver@.service
+++ b/resources/onedriver@.service
@@ -3,9 +3,9 @@ Description=onedriver
 
 [Service]
 ExecStart=/usr/bin/onedriver -c "%C/onedriver/%i" %I
-ExecStop=/usr/bin/fusermount -uz %I
-ExecStopPost=/usr/bin/sleep 1
-Restart=no
+ExecStopPost=-/usr/bin/fusermount -uz %I
+ExecStopPost=/usr/bin/sleep 3
+Restart=on-failure
 
 [Install]
 WantedBy=default.target

--- a/resources/onedriver@.service
+++ b/resources/onedriver@.service
@@ -3,9 +3,10 @@ Description=onedriver
 
 [Service]
 ExecStart=/usr/bin/onedriver -c "%C/onedriver/%i" %I
-ExecStopPost=/usr/bin/fusermount -uz %I; exit 0
-ExecStopPost=/usr/bin/sleep 3
-Restart=on-failure
+ExecStopPost=/usr/bin/fusermount -uz %I
+Restart=on-abnormal
+RestartSec=3
+RestartForceExitStatus=2
 
 [Install]
 WantedBy=default.target

--- a/resources/onedriver@.service
+++ b/resources/onedriver@.service
@@ -3,7 +3,7 @@ Description=onedriver
 
 [Service]
 ExecStart=/usr/bin/onedriver -c "%C/onedriver/%i" %I
-ExecStopPost=-/usr/bin/fusermount -uz %I
+ExecStopPost=/usr/bin/fusermount -uz %I; exit 0
 ExecStopPost=/usr/bin/sleep 3
 Restart=on-failure
 


### PR DESCRIPTION
This used to always restart, I'm not sure if the change was intentional, but I want to propose a compromise:
- Sleep for 3 seconds: Systemctl will stop the service if it attempts to reload more than 5 times in 10 seconds. This ensures that we don't hit that limit.
- Restart on failure: This was `always` before, but I think it really only matters on failure.
- ExecStop -> ExecStopPost: This ensures that the script runs even if there was an error. The minus will ensure that if this errors, it will still continue (to the sleep command) We can have multiple ExecStopPost entries.