### PR TITLE
Rewrite offline check to count any HTTP status as being online

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.osc/
 compile_flags.txt
 .commit
 .date

--- a/fs/graph/graph.go
+++ b/fs/graph/graph.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/jstaf/onedriver/logger"
@@ -191,12 +191,13 @@ func GetDrive(auth *Auth) (Drive, error) {
 	return drive, json.Unmarshal(resp, &drive)
 }
 
-// IsOffline checks if an error is indicative of being offline.
+// IsOffline checks if an error string from Request() is indicative of being offline.
 func IsOffline(err error) bool {
 	if err == nil {
 		return false
 	}
-	return strings.Contains(err.Error(), "network is unreachable") ||
-		strings.Contains(err.Error(), "connection refused") ||
-		strings.Contains(err.Error(), "failure in name resolution")
+	// our error messages from Request() will be prefixed with "HTTP ### -" if we actually
+	// got an HTTP response (indicating we are not offline)
+	rexp := regexp.MustCompile("HTTP [0-9]+ - ")
+	return !rexp.MatchString(err.Error())
 }

--- a/launcher/onedriver.c
+++ b/launcher/onedriver.c
@@ -53,6 +53,11 @@ char *fs_account_name(const char *instance) {
     sprintf(fname, "%s/onedriver/%s/auth_tokens.json", cachedir, instance);
 
     char *account_name = NULL;
+    struct stat st;
+    if (stat(fname, &st) != 0) {
+        return account_name;
+    }
+
     GError *error = NULL;
     JsonParser *parser = json_parser_new();
     json_parser_load_from_file(parser, fname, &error);


### PR DESCRIPTION
This changes the IsOffline check to count anything without "HTTP ###" in the error code (added by `Request()`) as an "offline" error.