### PR TITLE
Disallow removal of nonempty directories

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -92,6 +92,28 @@ func TestMkdirRmdir(t *testing.T) {
 	failOnErr(t, exec.Command("mkdir", fname).Run())
 }
 
+// Test that attempting to move a directory onto an existing directory functions
+// correctly. The contents of the two directories should be merged.
+func TestDirMerge(t *testing.T) {
+	t.Parallel()
+	dest := filepath.Join(TestDir, "preexisting_dir")
+	failOnErr(t, os.Mkdir(dest, 0755))
+	failOnErr(t, ioutil.WriteFile(filepath.Join(dest, "file1.txt"), []byte("this is file 1"), 0644))
+
+	failOnErr(t, os.Mkdir("/tmp/preexisting_dir", 0755))
+	failOnErr(t, ioutil.WriteFile("/tmp/preexisting_dir/file2.txt", []byte("this is file 2"), 0644))
+
+	// now move the file from /tmp to OneDrive and confirm the directories merge
+	failOnErr(t, exec.Command("mv", "/tmp/preexisting_dir", TestDir).Run())
+
+	if _, err := os.Stat(filepath.Join(dest, "file1.txt")); err != nil {
+		t.Error(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "file2.txt")); err != nil {
+		t.Error(err)
+	}
+}
+
 // test that we can write to a file and read its contents back correctly
 func TestReadWrite(t *testing.T) {
 	t.Parallel()

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -93,24 +93,20 @@ func TestMkdirRmdir(t *testing.T) {
 }
 
 // Test that attempting to move a directory onto an existing directory functions
-// correctly. The contents of the two directories should be merged.
-func TestDirMerge(t *testing.T) {
+// correctly. The cross-device move should fail when mv can't remove the target directory.
+func TestInterDeviceMove(t *testing.T) {
 	t.Parallel()
 	dest := filepath.Join(TestDir, "preexisting_dir")
 	failOnErr(t, os.Mkdir(dest, 0755))
 	failOnErr(t, ioutil.WriteFile(filepath.Join(dest, "file1.txt"), []byte("this is file 1"), 0644))
 
-	failOnErr(t, os.Mkdir("/tmp/preexisting_dir", 0755))
+	os.Mkdir("/tmp/preexisting_dir", 0755)
 	failOnErr(t, ioutil.WriteFile("/tmp/preexisting_dir/file2.txt", []byte("this is file 2"), 0644))
 
-	// now move the file from /tmp to OneDrive and confirm the directories merge
-	failOnErr(t, exec.Command("mv", "/tmp/preexisting_dir", TestDir).Run())
-
-	if _, err := os.Stat(filepath.Join(dest, "file1.txt")); err != nil {
-		t.Error(err)
-	}
-	if _, err := os.Stat(filepath.Join(dest, "file2.txt")); err != nil {
-		t.Error(err)
+	// now move the file from /tmp to OneDrive
+	_, err := exec.Command("mv", "/tmp/preexisting_dir", TestDir).CombinedOutput()
+	if err == nil {
+		t.Fatal("Inter-device copy succeeded and overwrote a non-empty directory")
 	}
 }
 

--- a/fs/inode.go
+++ b/fs/inode.go
@@ -709,6 +709,10 @@ func (i *Inode) Unlink(ctx context.Context, name string) syscall.Errno {
 
 // Rmdir deletes a child directory. Reuses Unlink.
 func (i *Inode) Rmdir(ctx context.Context, name string) syscall.Errno {
+	child, _ := i.GetCache().GetChild(i.ID(), name, nil)
+	if child != nil && child.HasChildren() {
+		return syscall.ENOTEMPTY
+	}
 	return i.Unlink(ctx, name)
 }
 

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -83,7 +83,10 @@ func TestMain(m *testing.M) {
 
 	// cleanup from last run
 	log.Info("Setup test environment ---------------------------------")
-	os.RemoveAll(TestDir)
+	if err := os.RemoveAll(TestDir); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	os.Mkdir(TestDir, 0755)
 	os.Mkdir(DeltaDir, 0755)
 


### PR DESCRIPTION
Previously it was dependent on whatever was using the onedriver filesystem to avoid removing nonempty directories. Now the filesystem itself disallows deletion of nonempty directories.