### PR TITLE
Support opensuse builds

### DIFF
--- a/onedriver.spec
+++ b/onedriver.spec
@@ -7,7 +7,11 @@ License:       GPLv3
 URL:           https://github.com/jstaf/onedriver
 Source0:       https://github.com/jstaf/onedriver/archive/refs/tags/v%{version}.tar.gz
 
+%if 0%{?suse_version}
+BuildRequires: go >= 1.12
+%else
 BuildRequires: golang >= 1.12.0
+%endif
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: pkg-config


### PR DESCRIPTION
I re-looked into this and all that's needed to support building via mock is this bit here to use the different name for the golang package: https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code