### PR TITLE
Fix segfault on write if file contents uninitialized

### DIFF
--- a/fs/upload_manager.go
+++ b/fs/upload_manager.go
@@ -126,7 +126,7 @@ func (u *UploadManager) uploadLoop(duration time.Duration) {
 						"id":    session.ID,
 						"oldID": session.OldID,
 						"name":  session.Name,
-					}).Debug("Upload completed!")
+					}).Info("Upload completed!")
 
 					// ID changed during upload, move to new ID
 					if session.OldID != session.ID {

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -196,7 +196,7 @@ func (u *UploadSession) Upload(auth *graph.Auth) error {
 	log.WithFields(log.Fields{
 		"id":   u.ID,
 		"name": u.Name,
-	}).Debug("Uploading file.")
+	}).Info("Uploading file.")
 	u.setState(uploadStarted, nil)
 
 	var uploadPath string


### PR DESCRIPTION
Fixes a bug where the fs can crash if Open() discarded the cache from a local item because its checksum didn't match.