### PR TITLE
Revert EL7 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRCS := $(shell find launcher/ -name *.c | grep -v _test)
 OBJS := $(SRCS:%.c=build/%.o)
 INC_DIRS := $(shell find launcher/ -type d | grep -v _test)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
-CFLAGS := ${CFLAGS} $(INC_FLAGS) $(shell pkg-config --cflags $(DEPS))
+CFLAGS := -std=gnu11 ${CFLAGS} $(INC_FLAGS) $(shell pkg-config --cflags $(DEPS))
 LDFLAGS := $(shell pkg-config --libs $(DEPS))
 
 # c test variables

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRCS := $(shell find launcher/ -name *.c | grep -v _test)
 OBJS := $(SRCS:%.c=build/%.o)
 INC_DIRS := $(shell find launcher/ -type d | grep -v _test)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
-CFLAGS := -std=gnu11 ${CFLAGS} $(INC_FLAGS) $(shell pkg-config --cflags $(DEPS))
+CFLAGS := ${CFLAGS} $(INC_FLAGS) $(shell pkg-config --cflags $(DEPS))
 LDFLAGS := $(shell pkg-config --libs $(DEPS))
 
 # c test variables

--- a/onedriver.spec
+++ b/onedriver.spec
@@ -12,15 +12,10 @@ BuildRequires: go >= 1.12
 %else
 BuildRequires: golang >= 1.12.0
 %endif
-%if 0%{?centos_ver} == 7 || 0%{?rhel_ver} == 7
-BuildRequires: pkgconfig
-BuildRequires: webkitgtk4-devel
-%else
-BuildRequires: pkg-config
-BuildRequires: webkit2gtk3-devel
-%endif
 BuildRequires: git
 BuildRequires: gcc
+BuildRequires: pkg-config
+BuildRequires: webkit2gtk3-devel
 BuildRequires: json-glib-devel
 
 %if 0%{?suse_version}
@@ -35,14 +30,11 @@ Requires: libjson-glib-1_0-0
 %endif
 # other EL distros
 %else
-%if 0%{?centos_ver} == 7 || 0%{?rhel_ver} == 7
-Requires: webkitgtk4
-%else
 Requires: webkit2gtk3
-%endif
 Requires: json-glib
 %endif
 Requires: fuse
+Suggests: systemd
 
 %description
 Onedriver is a native Linux filesystem for Microsoft Onedrive. Files and
@@ -57,7 +49,7 @@ break.
 # done via sed because #cgo flags appear to ignore #ifdef
 sed -i 's/webkit2gtk-4.0/webkit2gtk-4.1/g' fs/graph/oauth2_gtk.go
 %endif
-go build -mod=vendor -ldflags="-X main.commit=$(cat .commit)"
+GOOS=linux go build -mod=vendor -ldflags="-X main.commit=$(cat .commit)"
 make onedriver-launcher
 gzip resources/onedriver.1
 


### PR DESCRIPTION
EL7 distros don't support systemd user sessions - that breaks most of the package's functionality. This PR removes EL7 build support, since we can't really support persistent mounts via systemd user sessions or the GUI.

Ref: #185 