### PR TITLE
Add the "headless" auth functionality to the default build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ onedriver (0.12.0-1) focal; urgency=low
   * Switch to using zerolog instead of logrus for logging. Though zerolog is supposedly 
     faster, the real reason to switch is that it's much easier for me (and hopefully you)
     to read. Also, pretty colors!
+  * onedriver now gives you the option to choose to authenticate via the terminal when 
+    authenticating via the new --no-browser option (this is the functionality from the 
+    old "headless" build).
 
  -- Jeff Stafford <jeff.stafford@protonmail.com>  Tue, 2 Nov 2021 19:00:00 -0400
 

--- a/fs/graph/graph.go
+++ b/fs/graph/graph.go
@@ -68,7 +68,7 @@ func Request(resource string, auth *Auth, method string, content io.Reader) ([]b
 			Msg("Authentication token invalid or new app permissions required, " +
 				"forcing reauth before retrying.")
 
-		reauth := newAuth(auth.path)
+		reauth := newAuth(auth.path, false)
 		auth.AccessToken = reauth.AccessToken
 		auth.RefreshToken = reauth.RefreshToken
 		auth.ExpiresAt = reauth.ExpiresAt

--- a/fs/graph/oauth2_headless.go
+++ b/fs/graph/oauth2_headless.go
@@ -2,23 +2,7 @@
 
 package graph
 
-import (
-	"fmt"
-
-	"github.com/rs/zerolog/log"
-)
-
 // accountName arg is only present for compatibility with the non-headless C version.
 func getAuthCode(accountName string) string {
-	fmt.Printf("Please visit the following URL:\n%s\n\n", getAuthURL())
-	fmt.Println("Please enter the redirect URL once you are redirected to a " +
-		"blank page (after \"Let this app access your info?\"):")
-	var response string
-	fmt.Scanln(&response)
-	code, err := parseAuthCode(response)
-	if err != nil {
-		log.Fatal().Msg("No validation code returned, or code was invalid. " +
-			"Please restart the application and try again.")
-	}
-	return code
+	return getAuthCodeHeadless(accountName)
 }

--- a/fs/graph/setup_test.go
+++ b/fs/graph/setup_test.go
@@ -16,7 +16,7 @@ func TestMain(m *testing.M) {
 	defer f.Close()
 
 	// auth and log account metadata so we're extra sure who we're testing against
-	auth := Authenticate(".auth_tokens.json")
+	auth := Authenticate(".auth_tokens.json", false)
 	user, _ := GetUser(auth)
 	drive, _ := GetDrive(auth)
 	log.Info().

--- a/fs/offline/setup_test.go
+++ b/fs/offline/setup_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	exec.Command("fusermount", "-uz", mountLoc).Run()
 	os.Mkdir(mountLoc, 0755)
 
-	auth = graph.Authenticate(".auth_tokens.json")
+	auth = graph.Authenticate(".auth_tokens.json", false)
 	inode, err := graph.GetItem("root", auth)
 	if inode != nil || !graph.IsOffline(err) {
 		fmt.Println("These tests must be run offline.")

--- a/fs/setup_test.go
+++ b/fs/setup_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: f, TimeFormat: "15:04:05"})
 	defer f.Close()
 
-	auth = graph.Authenticate(".auth_tokens.json")
+	auth = graph.Authenticate(".auth_tokens.json", false)
 	fs = NewFilesystem(auth, "test.db")
 	server, _ := fuse.NewServer(
 		fs,

--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ func usage() {
 	fmt.Printf(`onedriver - A Linux client for Microsoft OneDrive.
 
 This program will mount your OneDrive account as a Linux filesystem at the
-specified mountpoint. Note that this is not a sync client - files are fetched
-on-demand and cached locally. Only files you actually use will be downloaded.
-While offline, the filesystem will be read-only until connectivity is re-
-established.
+specified mountpoint. Note that this is not a sync client - files are only
+fetched on-demand and cached locally. Only files you actually use will be
+downloaded. While offline, the filesystem will be read-only until
+connectivity is re-established.
 
 Usage: onedriver [options] <mountpoint>
 
@@ -43,11 +43,12 @@ func main() {
 	// setup cli parsing
 	authOnly := flag.BoolP("auth-only", "a", false,
 		"Authenticate to OneDrive and then exit.")
-	headless := flag.Bool("headless", false,
+	headless := flag.BoolP("no-browser", "n", false,
 		"This disables launching the built-in web browser during authentication. "+
 			"Follow the instructions in the terminal to authenticate to OneDrive.")
-	logLevel := flag.StringP("log", "l", "debug", "Set logging level/verbosity. "+
-		"Can be one of: fatal, error, warn, info, debug, trace")
+	logLevel := flag.StringP("log", "l", "debug",
+		"Set logging level/verbosity for the filesystem. "+
+			"Can be one of: fatal, error, warn, info, debug, trace")
 	cacheDir := flag.StringP("cache-dir", "c", "",
 		"Change the default cache directory used by onedriver. "+
 			"Will be created if the path does not already exist.")
@@ -55,7 +56,8 @@ func main() {
 		"Delete the existing onedriver cache directory and then exit. "+
 			"Equivalent to resetting the program.")
 	versionFlag := flag.BoolP("version", "v", false, "Display program version.")
-	debugOn := flag.BoolP("debug", "d", false, "Enable FUSE debug logging.")
+	debugOn := flag.BoolP("debug", "d", false, "Enable FUSE debug logging. "+
+		"This logs communication between onedriver and the kernel.")
 	flag.BoolP("help", "h", false, "Displays this help message.")
 	flag.Usage = usage
 	flag.Parse()

--- a/onedriver.spec
+++ b/onedriver.spec
@@ -91,7 +91,10 @@ cp resources/%{name}.1.gz %{buildroot}/usr/share/man/man1
   bug where running ld inside the filesystem would cause it to crash.
 - Switch to using zerolog instead of logrus for logging. Though zerolog is supposedly 
   faster, the real reason to switch is that it's much easier for me (and hopefully you)
-  to read!
+  to read! Also, pretty colors!
+- onedriver now gives you the option to choose to authenticate via the terminal when 
+  authenticating via the new --no-browser option (this is the functionality from the 
+  old "headless" build).
 
 * Tue Aug 17 2021 Jeff Stafford <jeff.stafford@protonmail.com> - 0.11.2
 - onedriver now disallows rmdir on nonempty directories.

--- a/resources/onedriver.1
+++ b/resources/onedriver.1
@@ -1,6 +1,6 @@
 .\" Manpage for onedriver
 
-.TH man 1 "Aug 2021" "0.12.0" "onedriver man page"
+.TH man 1 "Nov 2021" "0.12.0" "onedriver man page"
 
 .SH NAME
 onedriver \- A native Linux client for Microsoft OneDrive.
@@ -29,24 +29,28 @@ Authenticate to OneDrive and then exit.
 Change the default cache directory used by onedriver. Will be created if the path does not already exist. The \fIdir\fR argument specifies the location. 
 
 .TP
-.BR \-d , "\-\-debug"
-Enable FUSE debug logging.
+.BR \-d , " \-\-debug"
+Enable FUSE debug logging. This logs communication between onedriver and the kernel.
 
 .TP
-.BR \-h , "\-\-help"
+.BR \-h , " \-\-help"
 Displays a help message.
 
 .TP
-.BR \-l , "\-\-log "\fIlevel
+.BR \-l , " \-\-log "\fIlevel
 Set logging level/verbosity. \fIlevel\fR can be one of: 
 .BR fatal ", " error ", " warn ", " info ", " debug " or " trace " (default is " debug ")."
 
 .TP
-.BR \-v , "\-\-version"
+.BR \-n , " \-\-no\-browser"
+This disables launching the built-in web browser during authentication. Follow the instructions in the terminal to authenticate to OneDrive.
+
+.TP
+.BR \-v , " \-\-version"
 Display program version.
 
 .TP
-.BR \-w , "\-\-wipe-cache"
+.BR \-w , " \-\-wipe-cache"
 Delete the existing onedriver cache directory and then exit. Equivalent to resetting the program.
 
 


### PR DESCRIPTION
Users can now choose to authenticate via the terminal if so desired (instead of being forced to use the browser in the normal version of the build).