### PR TITLE
Avoid lock during hashing of file contents

### DIFF
--- a/fs/offline/setup_test.go
+++ b/fs/offline/setup_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/hanwen/go-fuse/v2/fuse"
-	odfs "github.com/jstaf/onedriver/fs"
+	"github.com/jstaf/onedriver/fs"
 	"github.com/jstaf/onedriver/fs/graph"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 
 	// reuses the cached data from the previous tests
 	server, _ := fuse.NewServer(
-		odfs.NewFilesystem(auth, "test.db"),
+		fs.NewFilesystem(auth, "test.db"),
 		mountLoc,
 		&fuse.MountOptions{
 			Name:          "onedriver",
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	// setup sigint handler for graceful unmount on interrupt/terminate
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGABRT)
-	go odfs.UnmountHandler(sigChan, server)
+	go fs.UnmountHandler(sigChan, server)
 
 	// mount fs in background thread
 	go server.Serve()

--- a/fs/upload_session.go
+++ b/fs/upload_session.go
@@ -103,22 +103,21 @@ func NewUploadSession(inode *Inode, data *[]byte) (*UploadSession, error) {
 		return nil, errors.New("data to upload cannot be nil")
 	}
 
-	inode.RLock()
-	defer inode.RUnlock()
-
 	// create a generic session for all files
+	inode.RLock()
 	session := UploadSession{
 		ID:       inode.DriveItem.ID,
 		OldID:    inode.DriveItem.ID,
 		ParentID: inode.DriveItem.Parent.ID,
 		NodeID:   inode.nodeID,
 		Name:     inode.DriveItem.Name,
-		Size:     uint64(len(*data)), // just in case it somehow differs
 		Data:     *data,
 		ModTime:  *inode.DriveItem.ModTime,
 	}
+	inode.RUnlock()
 
 	// compute both hashes for now, session does not know the drivetype
+	session.Size = uint64(len(*data)) // just in case it somehow differs
 	session.SHA1Hash = graph.SHA1Hash(data)
 	session.QuickXORHash = graph.QuickXORHash(data)
 	return &session, nil


### PR DESCRIPTION
We don't actually need to lock the file while it is being hashed. In all cases, we're working on a copy of the file's data. So this reduces the amount of time that the file needs to be locked.