### PR TITLE
Fix Fedora 35 authorization prompt failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
             gcc \
             pkg-config \
             libwebkit2gtk-4.0-dev \
+            libglib2.0-dev \
             libjson-glib-dev \
             make \
             wget \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
             gcc \
             pkg-config \
             libwebkit2gtk-4.0-dev \
-            libglib2.0-dev \
             libjson-glib-dev \
             make \
             wget \

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -12,7 +12,50 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                          GTlsCertificate *certificate,
                                          GTlsCertificateFlags errors,
                                          gpointer user_data) {
-    g_print("Webkit load failed for %s: %d\n", failing_uri, errors);
+    char *reason;
+    switch (errors) {
+    case 0:
+        reason = "No error - There was no error verifying the "
+                 "certificate.";
+        break;
+    case G_TLS_CERTIFICATE_UNKNOWN_CA:
+        reason = "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
+                 "not known.";
+        break;
+    case G_TLS_CERTIFICATE_BAD_IDENTITY:
+        reason = "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
+                 "expected identity of "
+                 "the site that it was retrieved from.";
+        break;
+    case G_TLS_CERTIFICATE_NOT_ACTIVATED:
+        reason = "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
+                 "still in the future.";
+        break;
+    case G_TLS_CERTIFICATE_EXPIRED:
+        reason = "G_TLS_CERTIFICATE_EXPIRED - The certificate has expired.";
+        break;
+    case G_TLS_CERTIFICATE_REVOKED:
+        reason = "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
+                 "to the "
+                 "GTlsConnection's certificate revocation list.";
+        break;
+    case G_TLS_CERTIFICATE_INSECURE:
+        reason = "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "
+                 "insecure.";
+        break;
+    case G_TLS_CERTIFICATE_GENERIC_ERROR:
+        reason = "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
+                 "the certificate.";
+        break;
+    default:
+        snprintf(reason, 256,
+                 "Multiple failures (%d) - There were multiple errors during certificate "
+                 "verification.",
+                 errors);
+        break;
+    }
+
+    g_print("Webkit load failed with TLS errors for %s : %s\n", failing_uri, reason);
     return false;
 }
 

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -1,3 +1,4 @@
+#include <glib.h>
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>
@@ -17,45 +18,53 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                          gpointer user_data) {
     char *reason;
     switch (errors) {
-    case 0:
-        reason = "No error - There was no error verifying the "
-                 "certificate.";
-        break;
-    case G_TLS_CERTIFICATE_UNKNOWN_CA:
-        reason = "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
-                 "not known.";
-        break;
-    case G_TLS_CERTIFICATE_BAD_IDENTITY:
-        reason = "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
-                 "expected identity of "
-                 "the site that it was retrieved from.";
-        break;
-    case G_TLS_CERTIFICATE_NOT_ACTIVATED:
-        reason = "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
-                 "still in the future.";
-        break;
-    case G_TLS_CERTIFICATE_EXPIRED:
-        reason = "G_TLS_CERTIFICATE_EXPIRED - The certificate has expired.";
-        break;
-    case G_TLS_CERTIFICATE_REVOKED:
-        reason = "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
-                 "to the "
-                 "GTlsConnection's certificate revocation list.";
-        break;
-    case G_TLS_CERTIFICATE_INSECURE:
-        reason = "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "
-                 "insecure.";
-        break;
-    case G_TLS_CERTIFICATE_GENERIC_ERROR:
-        reason = "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
-                 "the certificate.";
-        break;
-    default:
-        snprintf(reason, 256,
-                 "Multiple failures (%d) - There were multiple errors during certificate "
-                 "verification.",
-                 errors);
-        break;
+        case 0:
+            reason =
+                "No error - There was no error verifying the "
+                "certificate.";
+            break;
+        case G_TLS_CERTIFICATE_UNKNOWN_CA:
+            reason =
+                "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
+                "not known.";
+            break;
+        case G_TLS_CERTIFICATE_BAD_IDENTITY:
+            reason =
+                "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
+                "expected identity of "
+                "the site that it was retrieved from.";
+            break;
+        case G_TLS_CERTIFICATE_NOT_ACTIVATED:
+            reason =
+                "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
+                "still in the future.";
+            break;
+        case G_TLS_CERTIFICATE_EXPIRED:
+            reason = "G_TLS_CERTIFICATE_EXPIRED - The certificate has expired.";
+            break;
+        case G_TLS_CERTIFICATE_REVOKED:
+            reason =
+                "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
+                "to the "
+                "GTlsConnection's certificate revocation list.";
+            break;
+        case G_TLS_CERTIFICATE_INSECURE:
+            reason =
+                "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "
+                "insecure.";
+            break;
+        case G_TLS_CERTIFICATE_GENERIC_ERROR:
+            reason =
+                "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
+                "the certificate.";
+            break;
+        default:
+            snprintf(
+                reason, 256,
+                "Multiple failures (%d) - There were multiple errors during certificate "
+                "verification.",
+                errors);
+            break;
     }
 
     g_print("Webkit load failed with TLS errors for %s : %s\n", failing_uri, reason);
@@ -74,8 +83,9 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                                           "acctcdn.msauth.net");
         webkit_web_context_allow_tls_certificate_for_host(context, certificate,
                                                           "acctcdn.msftauth.net");
-        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
-                "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
+        g_print(
+            "Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
+            "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
         webkit_web_view_reload(web_view);
         return true;
     }

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -49,8 +49,7 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
     char *reason;
     switch (errors) {
     case 0:
-        reason = "No error - There was no error verifying the "
-                 "certificate.";
+        reason = "No error - There was no error verifying the certificate.";
         break;
     case G_TLS_CERTIFICATE_UNKNOWN_CA:
         reason = "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
@@ -58,8 +57,7 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
         break;
     case G_TLS_CERTIFICATE_BAD_IDENTITY:
         reason = "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
-                 "expected identity of "
-                 "the site that it was retrieved from.";
+                 "expected identity of the site that it was retrieved from.";
         break;
     case G_TLS_CERTIFICATE_NOT_ACTIVATED:
         reason = "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
@@ -70,8 +68,7 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
         break;
     case G_TLS_CERTIFICATE_REVOKED:
         reason = "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
-                 "to the "
-                 "GTlsConnection's certificate revocation list.";
+                 "to the GTlsConnection's certificate revocation list.";
         break;
     case G_TLS_CERTIFICATE_INSECURE:
         reason = "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -8,6 +8,14 @@
  */
 static void destroy_window(GtkWidget *widget, gpointer data) { gtk_main_quit(); }
 
+static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_uri,
+                                         GTlsCertificate *certificate,
+                                         GTlsCertificateFlags errors,
+                                         gpointer user_data) {
+    g_print("Webkit load failed for %s: %d\n", failing_uri, errors);
+    return false;
+}
+
 /**
  * Catch redirects once authentication completes.
  */
@@ -50,6 +58,8 @@ char *webkit_auth_window(char *auth_url, char *account_name) {
     auth_redirect_value[0] = '\0';
     g_signal_connect(web_view, "load-changed", G_CALLBACK(web_view_load_changed),
                      &auth_redirect_value);
+    g_signal_connect(web_view, "load-failed-with-tls-errors",
+                     G_CALLBACK(web_view_load_failed_tls), NULL);
     g_signal_connect(auth_window, "destroy", G_CALLBACK(destroy_window), web_view);
 
     // show and grab focus

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -67,9 +67,15 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
     if (errors & G_TLS_CERTIFICATE_GENERIC_ERROR &&
         strncmp("account.live.com", host, 17) == 0) {
         WebKitWebContext *context = webkit_web_view_get_context(web_view);
+        // allow these failing domains from the webpage and reload
         webkit_web_context_allow_tls_certificate_for_host(context, certificate,
                                                           "account.live.com");
-        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com only.\n");
+        webkit_web_context_allow_tls_certificate_for_host(context, certificate,
+                                                          "acctcdn.msauth.net");
+        webkit_web_context_allow_tls_certificate_for_host(context, certificate,
+                                                          "acctcdn.msftauth.net");
+        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
+                "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
         webkit_web_view_reload(web_view);
         return true;
     }

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -103,8 +103,9 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                                           "acctcdn.msauth.net");
         webkit_web_context_allow_tls_certificate_for_host(context, certificate,
                                                           "acctcdn.msftauth.net");
-        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
-                "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
+        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for this certificate as a "
+                "workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2024296 - "
+                "reloading page.\n");
         webkit_web_view_reload(web_view);
         return true;
     }

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -24,7 +24,9 @@ char *uri_get_host(char *uri) {
         } else if (start > 0) {
             int len = i - start;
             char *host = malloc(len);
-            return strncpy(host, uri + start, len);
+            strncpy(host, uri + start, len);
+            host[len] = '\0';
+            return host;
         }
     }
 

--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -1,4 +1,3 @@
-#include <glib.h>
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <string.h>
@@ -18,53 +17,45 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                          gpointer user_data) {
     char *reason;
     switch (errors) {
-        case 0:
-            reason =
-                "No error - There was no error verifying the "
-                "certificate.";
-            break;
-        case G_TLS_CERTIFICATE_UNKNOWN_CA:
-            reason =
-                "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
-                "not known.";
-            break;
-        case G_TLS_CERTIFICATE_BAD_IDENTITY:
-            reason =
-                "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
-                "expected identity of "
-                "the site that it was retrieved from.";
-            break;
-        case G_TLS_CERTIFICATE_NOT_ACTIVATED:
-            reason =
-                "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
-                "still in the future.";
-            break;
-        case G_TLS_CERTIFICATE_EXPIRED:
-            reason = "G_TLS_CERTIFICATE_EXPIRED - The certificate has expired.";
-            break;
-        case G_TLS_CERTIFICATE_REVOKED:
-            reason =
-                "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
-                "to the "
-                "GTlsConnection's certificate revocation list.";
-            break;
-        case G_TLS_CERTIFICATE_INSECURE:
-            reason =
-                "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "
-                "insecure.";
-            break;
-        case G_TLS_CERTIFICATE_GENERIC_ERROR:
-            reason =
-                "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
-                "the certificate.";
-            break;
-        default:
-            snprintf(
-                reason, 256,
-                "Multiple failures (%d) - There were multiple errors during certificate "
-                "verification.",
-                errors);
-            break;
+    case 0:
+        reason = "No error - There was no error verifying the "
+                 "certificate.";
+        break;
+    case G_TLS_CERTIFICATE_UNKNOWN_CA:
+        reason = "G_TLS_CERTIFICATE_UNKNOWN_CA - The signing certificate authority is "
+                 "not known.";
+        break;
+    case G_TLS_CERTIFICATE_BAD_IDENTITY:
+        reason = "G_TLS_CERTIFICATE_BAD_IDENTITY - The certificate does not match the "
+                 "expected identity of "
+                 "the site that it was retrieved from.";
+        break;
+    case G_TLS_CERTIFICATE_NOT_ACTIVATED:
+        reason = "G_TLS_CERTIFICATE_NOT_ACTIVATED - The certificate’s activation time is "
+                 "still in the future.";
+        break;
+    case G_TLS_CERTIFICATE_EXPIRED:
+        reason = "G_TLS_CERTIFICATE_EXPIRED - The certificate has expired.";
+        break;
+    case G_TLS_CERTIFICATE_REVOKED:
+        reason = "G_TLS_CERTIFICATE_REVOKED - The certificate has been revoked according "
+                 "to the "
+                 "GTlsConnection's certificate revocation list.";
+        break;
+    case G_TLS_CERTIFICATE_INSECURE:
+        reason = "G_TLS_CERTIFICATE_INSECURE - The certificate’s algorithm is considered "
+                 "insecure.";
+        break;
+    case G_TLS_CERTIFICATE_GENERIC_ERROR:
+        reason = "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
+                 "the certificate.";
+        break;
+    default:
+        snprintf(reason, 256,
+                 "Multiple failures (%d) - There were multiple errors during certificate "
+                 "verification.",
+                 errors);
+        break;
     }
 
     g_print("Webkit load failed with TLS errors for %s : %s\n", failing_uri, reason);
@@ -83,9 +74,8 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
                                                           "acctcdn.msauth.net");
         webkit_web_context_allow_tls_certificate_for_host(context, certificate,
                                                           "acctcdn.msftauth.net");
-        g_print(
-            "Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
-            "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
+        g_print("Ignoring G_TLS_CERTIFICATE_GENERIC_ERROR for account.live.com, "
+                "acctcdn.msauth.net, acctcdn.msftauth.net.\n");
         webkit_web_view_reload(web_view);
         return true;
     }

--- a/fs/graph/oauth2_gtk.go
+++ b/fs/graph/oauth2_gtk.go
@@ -34,3 +34,17 @@ func getAuthCode(accountName string) string {
 	}
 	return code
 }
+
+// uriGetHost is exclusively here for testing because we cannot use CGo in tests,
+// but can use functions that invoke CGo in tests.
+func uriGetHost(uri string) string {
+	input := C.CString(uri)
+	defer C.free(unsafe.Pointer(input))
+
+	host := C.uri_get_host(input)
+	defer C.free(unsafe.Pointer(host))
+	if host == nil {
+		return ""
+	}
+	return C.GoString(host)
+}

--- a/fs/graph/oauth2_gtk.go
+++ b/fs/graph/oauth2_gtk.go
@@ -3,7 +3,7 @@
 package graph
 
 /*
-#cgo linux pkg-config: webkit2gtk-4.0 glib-2.0
+#cgo linux pkg-config: webkit2gtk-4.0
 #include "stdlib.h"
 #include "oauth2_gtk.h"
 */

--- a/fs/graph/oauth2_gtk.go
+++ b/fs/graph/oauth2_gtk.go
@@ -3,7 +3,7 @@
 package graph
 
 /*
-#cgo linux pkg-config: webkit2gtk-4.0
+#cgo linux pkg-config: webkit2gtk-4.0 glib-2.0
 #include "stdlib.h"
 #include "oauth2_gtk.h"
 */

--- a/fs/graph/oauth2_gtk.h
+++ b/fs/graph/oauth2_gtk.h
@@ -1,3 +1,4 @@
 #pragma once
 
+char *uri_get_host(char *uri);
 char *webkit_auth_window(char *auth_url, char *account_name);

--- a/fs/graph/oauth2_gtk_test.go
+++ b/fs/graph/oauth2_gtk_test.go
@@ -1,0 +1,22 @@
+// +build linux,cgo
+
+package graph
+
+import "testing"
+
+func TestURIGetHost(t *testing.T) {
+	host := uriGetHost("this won't work")
+	if host != "" {
+		t.Errorf("Func should return NULL if not a valid URI, got %s\n", host)
+	}
+
+	host = uriGetHost("https://account.live.com/test/index.html")
+	if host != "account.live.com" {
+		t.Errorf("Got %s, wanted \"account.live.com\"\n", host)
+	}
+
+	host = uriGetHost("http://account.live.com")
+	if host != "account.live.com" {
+		t.Errorf("Got %s, wanted \"account.live.com\"\n", host)
+	}
+}

--- a/fs/graph/oauth2_gtk_test.go
+++ b/fs/graph/oauth2_gtk_test.go
@@ -12,11 +12,11 @@ func TestURIGetHost(t *testing.T) {
 
 	host = uriGetHost("https://account.live.com/test/index.html")
 	if host != "account.live.com" {
-		t.Errorf("Got %s, wanted \"account.live.com\"\n", host)
+		t.Errorf("With extra path: got \"%s\", wanted \"account.live.com\"\n", host)
 	}
 
 	host = uriGetHost("http://account.live.com")
 	if host != "account.live.com" {
-		t.Errorf("Got %s, wanted \"account.live.com\"\n", host)
+		t.Errorf("No extra path: got \"%s\", wanted \"account.live.com\"\n", host)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -82,6 +82,9 @@ func main() {
 		os.Exit(0)
 	}
 
+	zerolog.SetGlobalLevel(StringToLevel(*logLevel))
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
+
 	// authenticate/re-authenticate if necessary
 	os.MkdirAll(dir, 0700)
 	authPath := filepath.Join(dir, "auth_tokens.json")
@@ -90,9 +93,6 @@ func main() {
 		graph.Authenticate(authPath, *headless)
 		os.Exit(0)
 	}
-
-	zerolog.SetGlobalLevel(StringToLevel(*logLevel))
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "15:04:05"})
 
 	// determine and validate mountpoint
 	if len(flag.Args()) == 0 {


### PR DESCRIPTION
Not sure how great of a fix this is - currently we're getting a "generic TLS error" that has nothing to do with the certificate (it's fine in Firefox/curl/openssl), so this adds a workaround to allow only that certificate+the associated CDN certs when we encounter this specific error only.