### PR TITLE
Add an error dialog to Launcher when selecting an invalid mountpoint

### DIFF
--- a/cmd/onedriver-launcher/main.go
+++ b/cmd/onedriver-launcher/main.go
@@ -85,10 +85,15 @@ func activateCallback(app *gtk.Application) {
 	mountpointBtn.SetTooltipText("Add a new OneDrive account.")
 	mountpointBtn.Connect("clicked", func(button *gtk.Button) {
 		mount := ui.DirChooser("Select a mountpoint")
+		if mount == "" {
+			// File choser was canceled
+			return
+		}
 		if !ui.MountpointIsValid(mount) {
 			log.Error().Str("mountpoint", mount).
 				Msg("Mountpoint was not valid (or user cancelled the operation). " +
 					"Mountpoint must be an empty directory.")
+			showErrorDialog("Mountpoint was not valid, mountpoint must be an empty directory (there might be hidden files).", window)
 			return
 		}
 
@@ -152,6 +157,18 @@ func activateCallback(app *gtk.Application) {
 	})
 
 	window.ShowAll()
+}
+
+func showErrorDialog(msg string, parentWindow gtk.IWindow) {
+	messageDialog := gtk.MessageDialogNew(
+		parentWindow,
+		gtk.DIALOG_DESTROY_WITH_PARENT,
+		gtk.MESSAGE_ERROR,
+		gtk.BUTTONS_CLOSE,
+		msg,
+	)
+	_ = messageDialog.Run()
+	messageDialog.Destroy()
 }
 
 // xdgOpenDir opens a folder in the user's default file browser.


### PR DESCRIPTION
First of all, thank you for a superb application!

## Case/Reason for change

When launching _Onedriver Launcher_ from desktop (non CLI), it will silently fail when trying to select a non-empty directory.

If the directory contains **hidden files** (like backup files from vim/drawio), this gets very confusing.

## Changes

* Added an error dialog to _Onedriver Launcher_ when trying to add an invalid mountpoint.

![image](https://user-images.githubusercontent.com/113136983/189208563-97544e3b-8649-484b-a965-14c8b425d747.png)

## Finally

Please let me know something should be changed, if the PR is malformed, or if for some reason it should be rejected :)