### PR TITLE
Fix pulling remote file with local filesystem cache

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -513,11 +513,19 @@ func (f *Filesystem) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.Ope
 	ctx.Info().Msg(
 		"Not using cached item due to file hash mismatch, fetching content from API.",
 	)
+
+    fd, err = f.content.OpenTruncate(id);
+    if err != nil {
+		ctx.Error().Err(err).Msg("Could not reset file cache.")
+		return fuse.EIO
+    }
+
 	size, err := graph.GetItemContentStream(id, f.auth, fd)
 	if err != nil {
 		ctx.Error().Err(err).Msg("Failed to fetch remote content.")
 		return fuse.EREMOTEIO
 	}
+
 	inode.DriveItem.Size = size
 	return fuse.OK
 }


### PR DESCRIPTION
With the latest local file based caching system, accessing a cached file that has been changed remotely does not work properly. The new content is actually being tacked on to the end of the cache file descriptor, resulting in invalid data. This pull request resets and properly updates the file's local cache when it is accessed with remote changes. 