### PR TITLE
Fix file redownloads, Ubuntu 20/Debian 11 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ tmp/
 *.core
 *.gdb
 vgcore.*
-__debug_bin
+__debug_bin*
 
 # do not include binaries, but do include sources
 onedriver

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all, test, srpm, rpm, dsc, changes, deb, clean, install, uninstall
+.PHONY: all, test, test-init, srpm, rpm, dsc, changes, deb, clean, install, uninstall
 
 # autocalculate software/package versions
 VERSION := $(shell grep Version onedriver.spec | sed 's/Version: *//g')
@@ -117,6 +117,13 @@ onedriver_$(VERSION)-$(RELEASE)_amd64.deb: onedriver_$(VERSION)-$(RELEASE).dsc
 # a large text file for us to test upload sessions with. #science
 dmel.fa:
 	curl ftp://ftp.ensemblgenomes.org/pub/metazoa/release-42/fasta/drosophila_melanogaster/dna/Drosophila_melanogaster.BDGP6.22.dna.chromosome.X.fa.gz | zcat > $@
+
+
+# setup tests for the first time on a new computer
+test-init: onedriver
+	go install github.com/rakyll/gotest@latest
+	mkdir -p mount/
+	$< -a mount/	
 
 
 # For offline tests, the test binary is built online, then network access is

--- a/README.md
+++ b/README.md
@@ -2,33 +2,33 @@
 [![Coverage Status](https://coveralls.io/repos/github/jstaf/onedriver/badge.svg?branch=master)](https://coveralls.io/github/jstaf/onedriver?branch=master)
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/jstaf/onedriver/package/onedriver/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/jstaf/onedriver/package/onedriver/)
 
-onedriver
-======================================
+# onedriver
 
 **onedriver is a native Linux filesystem for Microsoft OneDrive.**
 
 onedriver is a network filesystem that gives your computer direct access to your
-files on Microsoft OneDrive. This is not a sync client. Instead of syncing files, 
-onedriver performs an on-demand download of files when your computer attempts to
-use them. onedriver allows you to use files on OneDrive as if they were files on
-your local computer.
+files on Microsoft OneDrive. This is not a sync client. Instead of syncing
+files, onedriver performs an on-demand download of files when your computer
+attempts to use them. onedriver allows you to use files on OneDrive as if they
+were files on your local computer.
 
 onedriver is extremely straightforwards to use:
 
-* Install onedriver using your favorite installation method.
-* Click the "+" button in the app to setup one or more OneDrive accounts.
-  (There's a command-line workflow for those who prefer doing things that way too!)
-* Just start using your files on OneDrive as if they were normal files.
+- Install onedriver using your favorite installation method.
+- Click the "+" button in the app to setup one or more OneDrive accounts.
+  (There's a command-line workflow for those who prefer doing things that way
+  too!)
+- Just start using your files on OneDrive as if they were normal files.
 
 I've spent a lot of time trying to make onedriver fast, convenient, and easy to
 use. Though you can use it on servers, the goal here is to make it easy to work
 with OneDrive files on your Linux desktop. This allows you to easily sync files
-between any number of Windows, Mac, and Linux computers. You can setup your phone to
-auto-upload photos to OneDrive and edit and view them on your Linux computer.
-You can switch between LibreOffice on your local computer and the Microsoft 365
-online apps as needed when working. Want to migrate from Windows to Linux? Just
-throw all your Windows files into OneDrive, add your OneDrive account to Linux
-with onedriver, and call it a day.
+between any number of Windows, Mac, and Linux computers. You can setup your
+phone to auto-upload photos to OneDrive and edit and view them on your Linux
+computer. You can switch between LibreOffice on your local computer and the
+Microsoft 365 online apps as needed when working. Want to migrate from Windows
+to Linux? Just throw all your Windows files into OneDrive, add your OneDrive
+account to Linux with onedriver, and call it a day.
 
 **Microsoft OneDrive works on Linux.**
 
@@ -40,48 +40,49 @@ Getting started with your files on OneDrive is as easy as running:
 onedriver has several nice features that make it significantly more useful than
 other OneDrive clients:
 
-* **Files are only downloaded when you use them.** onedriver will only download
+- **Files are only downloaded when you use them.** onedriver will only download
   a file if you (or a program on your computer) uses that file. You don't need
-  to wait hours for a sync client to sync your entire OneDrive account to your local 
-  computer or try to guess which files and folders you might need later while
-  setting up a "selective sync". onedriver gives you instant access to *all* of your
-  files and only downloads the ones you use.
+  to wait hours for a sync client to sync your entire OneDrive account to your
+  local computer or try to guess which files and folders you might need later
+  while setting up a "selective sync". onedriver gives you instant access to
+  _all_ of your files and only downloads the ones you use.
 
-* **Bidirectional sync.** Although onedriver doesn't actually "sync" any files,
-  any changes that occur on OneDrive will be automatically reflected on your local
-  machine. onedriver will only redownload a file when you access a file that has 
-  been changed remotely on OneDrive. If you somehow simultaneously modify a file
-  both locally on your computer and also remotely on OneDrive, your local copy
-  will always take priority (to avoid you losing any local work).
+- **Bidirectional sync.** Although onedriver doesn't actually "sync" any files,
+  any changes that occur on OneDrive will be automatically reflected on your
+  local machine. onedriver will only redownload a file when you access a file
+  that has been changed remotely on OneDrive. If you somehow simultaneously
+  modify a file both locally on your computer and also remotely on OneDrive,
+  your local copy will always take priority (to avoid you losing any local
+  work).
 
-* **Can be used offline.** Files you've opened previously will be available even if 
-  your computer has no access to the internet. The filesystem becomes read-only
-  if you lose internet access, and automatically enables write access again when you 
-  reconnect to the internet.
+- **Can be used offline.** Files you've opened previously will be available even
+  if your computer has no access to the internet. The filesystem becomes
+  read-only if you lose internet access, and automatically enables write access
+  again when you reconnect to the internet.
 
-* **Fast.** Great care has been taken to ensure that onedriver never makes a
+- **Fast.** Great care has been taken to ensure that onedriver never makes a
   network request unless it actually needs to. onedriver caches both filesystem
   metadata and file contents both in memory and on-disk. Accessing your OneDrive
   files will be fast and snappy even if you're engaged in a fight to the death
   for the last power outlet at a coffeeshop with bad wifi. (This has definitely
   never happened to me before, why do you ask?)
 
-* **Has a user interface.** You can add and remove your OneDrive accounts without
-  ever using the command-line. Once you've added your OneDrive accounts, there's
-  no special interface beyond your normal file browser.
+- **Has a user interface.** You can add and remove your OneDrive accounts
+  without ever using the command-line. Once you've added your OneDrive accounts,
+  there's no special interface beyond your normal file browser.
 
-* **Free and open-source.** They're your files. Why should you have to pay to 
-  access them? onedriver is licensed under the GPLv3, which means you will *always*
-  have access to use onedriver to access your files on OneDrive.
+- **Free and open-source.** They're your files. Why should you have to pay to
+  access them? onedriver is licensed under the GPLv3, which means you will
+  _always_ have access to use onedriver to access your files on OneDrive.
 
 ## Quick start
 
 ### Fedora/CentOS/RHEL
 
-Users on Fedora/CentOS/RHEL systems are recommended to install onedriver from 
-[COPR](https://copr.fedorainfracloud.org/coprs/jstaf/onedriver/).
-This will install the latest version of onedriver through your package manager 
-and ensure it stays up-to-date with bugfixes and new features.
+Users on Fedora/CentOS/RHEL systems are recommended to install onedriver from
+[COPR](https://copr.fedorainfracloud.org/coprs/jstaf/onedriver/). This will
+install the latest version of onedriver through your package manager and ensure
+it stays up-to-date with bugfixes and new features.
 
 ```bash
 sudo dnf copr enable jstaf/onedriver
@@ -98,49 +99,51 @@ sudo zypper addrepo -g -r https://copr.fedorainfracloud.org/coprs/jstaf/onedrive
 sudo zypper --gpg-auto-import-keys refresh
 sudo zypper install onedriver
 
-# Tumbleweed 
+# Tumbleweed
 sudo zypper addrepo -g -r https://copr.fedorainfracloud.org/coprs/jstaf/onedriver/repo/opensuse-tumbleweed/jstaf-onedriver-opensuse-tumbleweed.repo onedriver
 sudo zypper --gpg-auto-import-keys refresh
 sudo zypper install onedriver
 ```
 
-### Ubuntu/Pop!_OS/Debian
+### Ubuntu/Pop!\_OS/Debian
 
-Ubuntu/Pop!_OS/Debian users can install onedriver from the
+Ubuntu/Pop!\_OS/Debian users can install onedriver from the
 [OpenSUSE Build Service](https://software.opensuse.org/download.html?project=home%3Ajstaf&package=onedriver)
 (despite the name, OBS also does a nice job of building packages for Debian).
 Like the COPR install, this will enable you to install onedriver through your
-package manager and install updates as they become available.
-If you previously installed onedriver via PPA,
-you can purge the old PPA from your system via:
+package manager and install updates as they become available. If you previously
+installed onedriver via PPA, you can purge the old PPA from your system via:
 `sudo add-apt-repository --remove ppa:jstaf/onedriver`
 
 ### Arch/Manjaro/EndeavourOS
 
-Arch/Manjaro/EndeavourOS users can install onedriver from the 
+Arch/Manjaro/EndeavourOS users can install onedriver from the
 [AUR](https://aur.archlinux.org/packages/onedriver/).
 
-Post-installation, you can start onedriver either via the `onedriver-launcher` 
+Post-installation, you can start onedriver either via the `onedriver-launcher`
 desktop app, or via the command line: `onedriver /path/to/mount/onedrive/at/`.
 
 ### Gentoo
 
-Gentoo users can install onedriver from [this ebuild overlay](https://github.com/foopsss/Ebuilds) provided by a user.
-If you don't want to add user-hosted overlays to your system you may copy the
-ebuild for the latest version to a local overlay, which can be created by following
-the instructions available in the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Creating_an_ebuild_repository).
+Gentoo users can install onedriver from
+[this ebuild overlay](https://github.com/foopsss/Ebuilds) provided by a user. If
+you don't want to add user-hosted overlays to your system you may copy the
+ebuild for the latest version to a local overlay, which can be created by
+following the instructions available in the
+[Gentoo Wiki](https://wiki.gentoo.org/wiki/Creating_an_ebuild_repository).
 
 Make sure to carefully review the ebuild for the package before installing it
 
 ## Multiple drives and starting OneDrive on login via systemd
 
 **Note:** You can also set this up through the GUI via the `onedriver-launcher`
-desktop app installed via rpm/deb/`make install`. You can skip this section
-if you're using the GUI. It's honestly easier.
+desktop app installed via rpm/deb/`make install`. You can skip this section if
+you're using the GUI. It's honestly easier.
 
-To start onedriver automatically and ensure you always have access to your files,
-you can start onedriver as a systemd user service. In this example, `$MOUNTPOINT`
-refers to where we want OneDrive to be mounted at (for instance, `~/OneDrive`).
+To start onedriver automatically and ensure you always have access to your
+files, you can start onedriver as a systemd user service. In this example,
+`$MOUNTPOINT` refers to where we want OneDrive to be mounted at (for instance,
+`~/OneDrive`).
 
 ```bash
 # create the mountpoint and determine the service name
@@ -160,11 +163,11 @@ journalctl --user -u $SERVICE_NAME --since today
 
 ## Building onedriver yourself
 
-In addition to the traditional [Go tooling](https://golang.org/dl/), 
-you will need a C compiler and development headers for `webkit2gtk-4.0`
-and `json-glib`. On Fedora, these can be obtained with 
-`dnf install golang gcc pkg-config webkit2gtk3-devel json-glib-devel`. 
-On Ubuntu, these dependencies can be installed with
+In addition to the traditional [Go tooling](https://golang.org/dl/), you will
+need a C compiler and development headers for `webkit2gtk-4.0` and `json-glib`.
+On Fedora, these can be obtained with
+`dnf install golang gcc pkg-config webkit2gtk3-devel json-glib-devel`. On
+Ubuntu, these dependencies can be installed with
 `apt install golang gcc pkg-config libwebkit2gtk-4.0-dev libjson-glib-dev`.
 
 ```bash
@@ -185,15 +188,19 @@ fusermount -uz mount
 
 The tests will write and delete files/folders on your onedrive account at the
 path `/onedriver_tests`. Note that the offline test suite requires `sudo` to
-remove network access to simulate being offline. 
+remove network access to simulate being offline.
 
 ```bash
+# setup test tooling for first time run
+make test-init
+
+# actually run tests
 make test
 ```
 
 ### Installation from source
 
-onedriver has multiple installation methods depending on your needs. 
+onedriver has multiple installation methods depending on your needs.
 
 ```bash
 # install directly from source
@@ -222,10 +229,10 @@ Don't panic! In most cases, the filesystem will report what happened to whatever
 program you're using. (As an example, an error mentioning a "read-only
 filesystem" indicates that your computer is currently offline.)
 
-If the filesystem appears to hang or "freeze" indefinitely, its possible the 
-fileystem has crashed. To resolve this, just restart the program by unmounting and 
-remounting things via the GUI or by running `fusermount -uz $MOUNTPOINT` on the 
-command-line. 
+If the filesystem appears to hang or "freeze" indefinitely, its possible the
+fileystem has crashed. To resolve this, just restart the program by unmounting
+and remounting things via the GUI or by running `fusermount -uz $MOUNTPOINT` on
+the command-line.
 
 If you really want to go back to a clean slate, onedriver can be completely
 reset (delete all cached local data) by deleting mounts in the GUI or running
@@ -233,19 +240,19 @@ reset (delete all cached local data) by deleting mounts in the GUI or running
 
 If you encounter a bug or have a feature request, open an issue in the "Issues"
 tab here on GitHub. The two most informative things you can put in a bug report
-are the logs from the bug/just before encountering the bug 
-(get logs via `journalctl --user -u $SERVICE_NAME --since today` ... see docs
-for correct value of `$SERVICE_NAME`) and/or instructions on how to reproduce
-the issue. Otherwise I have to guess what the problem is :disappointed:
+are the logs from the bug/just before encountering the bug (get logs via
+`journalctl --user -u $SERVICE_NAME --since today` ... see docs for correct
+value of `$SERVICE_NAME`) and/or instructions on how to reproduce the issue.
+Otherwise I have to guess what the problem is :disappointed:
 
 ## Known issues & disclaimer
 
-Many file browsers (like 
-[GNOME's Nautilus](https://gitlab.gnome.org/GNOME/nautilus/-/issues/1209)) 
-will attempt to automatically download all files within a directory in order to
+Many file browsers (like
+[GNOME's Nautilus](https://gitlab.gnome.org/GNOME/nautilus/-/issues/1209)) will
+attempt to automatically download all files within a directory in order to
 create thumbnail images. This is somewhat annoying, but only needs to happen
 once - after the initial thumbnail images have been created, thumbnails will
-persist between filesystem restarts. 
+persist between filesystem restarts.
 
 Microsoft does not support symbolic links (or anything remotely like them) on
 OneDrive. Attempting to create symbolic links within the filesystem returns
@@ -255,9 +262,9 @@ Recycle Bin APIs - if you want to empty or restore the OneDrive Recycle Bin, you
 must do so through the OneDrive web UI (onedriver uses the native system
 trash/restore functionality independently of the OneDrive Recycle Bin).
 
-onedriver loads files into memory when you access them. This makes things very 
-fast, but obviously doesn't work very well if you have very large files. Use a 
-sync client like [rclone](https://rclone.org/) if you need the ability to copy 
+onedriver loads files into memory when you access them. This makes things very
+fast, but obviously doesn't work very well if you have very large files. Use a
+sync client like [rclone](https://rclone.org/) if you need the ability to copy
 multi-gigabyte files to OneDrive.
 
 OneDrive is not a good place to backup files to. Use a tool like

--- a/fs/graph/drive_item.go
+++ b/fs/graph/drive_item.go
@@ -122,8 +122,10 @@ func GetItemContent(id string, auth *Auth) ([]byte, uint64, error) {
 	return buf.Bytes(), uint64(n), err
 }
 
-// GetItemContentStream is the same as GetItemContent, but writes data to an output
-// reader
+// GetItemContentStream is the same as GetItemContent, but writes data to an
+// output reader. This function assumes a brand-new io.Writer is used, so
+// "output" must be truncated if there is content already in the io.Writer
+// prior to use.
 func GetItemContentStream(id string, auth *Auth, output io.Writer) (uint64, error) {
 	// determine the size of the item
 	item, err := GetItem(id, auth)

--- a/fs/graph/hashes.go
+++ b/fs/graph/hashes.go
@@ -15,9 +15,11 @@ func SHA256Hash(data *[]byte) string {
 	return strings.ToUpper(fmt.Sprintf("%x", sha256.Sum256(*data)))
 }
 
-func SHA256HashStream(reader io.Reader) string {
+func SHA256HashStream(reader io.ReadSeeker) string {
+	reader.Seek(0, 0)
 	hash := sha256.New()
 	io.Copy(hash, reader)
+	reader.Seek(0, 0)
 	return strings.ToUpper(fmt.Sprintf("%x", hash.Sum(nil)))
 }
 
@@ -28,9 +30,11 @@ func SHA1Hash(data *[]byte) string {
 }
 
 // SHA1HashStream hashes the contents of a stream.
-func SHA1HashStream(reader io.Reader) string {
+func SHA1HashStream(reader io.ReadSeeker) string {
+	reader.Seek(0, 0)
 	hash := sha1.New()
 	io.Copy(hash, reader)
+	reader.Seek(0, 0)
 	return strings.ToUpper(fmt.Sprintf("%x", hash.Sum(nil)))
 }
 
@@ -43,9 +47,11 @@ func QuickXORHash(data *[]byte) string {
 }
 
 // QuickXORHashStream hashes a stream.
-func QuickXORHashStream(reader io.Reader) string {
+func QuickXORHashStream(reader io.ReadSeeker) string {
+	reader.Seek(0, 0)
 	hash := quickxorhash.New()
 	io.Copy(hash, reader)
+	reader.Seek(0, 0)
 	return base64.StdEncoding.EncodeToString(hash.Sum(nil))
 }
 
@@ -56,8 +62,6 @@ func (d *DriveItem) VerifyChecksum(checksum string) bool {
 	if len(checksum) == 0 || d.File == nil {
 		return false
 	}
-	// all checksums are converted to upper to avoid casing issues from whatever
-	// the API decides to return at this point in time.
 	return strings.EqualFold(d.File.Hashes.QuickXorHash, checksum)
 }
 

--- a/fs/graph/hashes_test.go
+++ b/fs/graph/hashes_test.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"testing"
 
@@ -66,4 +67,17 @@ func TestQuickXORHashReader(t *testing.T) {
 	reader := bytes.NewReader(content)
 	actual := QuickXORHashStream(reader)
 	assert.Equal(t, expected, actual)
+}
+
+func TestHashSeekPosition(t *testing.T) {
+	tmp, err := os.CreateTemp("", "onedriverHashTest")
+	if err != nil {
+		t.Error(err)
+	}
+	content := []byte("some test content")
+	io.Copy(tmp, bytes.NewBuffer(content))
+
+	assert.Equal(t, QuickXORHash(&content), QuickXORHashStream(tmp))
+	assert.Equal(t, SHA1Hash(&content), SHA1HashStream(tmp))
+	assert.Equal(t, SHA256Hash(&content), SHA256HashStream(tmp))
 }


### PR DESCRIPTION
This is an alternate fix for #350, and also fixes Ubuntu 20/Debian 11 support where the Go version is too old to use os.WriteFile and os.ReadFile.