### PR TITLE
README update to change the Gentoo overlay URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ desktop app, or via the command line: `onedriver /path/to/mount/onedrive/at/`.
 ### Gentoo
 
 Gentoo users can install onedriver from
-[this ebuild overlay](https://github.com/foopsss/Ebuilds) provided by a user. If
+[this ebuild overlay](https://github.com/foopsss/gentoo-overlay) provided by a user. If
 you don't want to add user-hosted overlays to your system you may copy the
 ebuild for the latest version to a local overlay, which can be created by
 following the instructions available in the


### PR DESCRIPTION
As per the commit name, I just changed the URL of my ebuilds repo since I renamed it to something that looks more "correct" now that I'm letting people know about it.

The old URL redirects people to the repo nonetheless but I'd like to have it changed just to be sure.