### PR TITLE
Create config directory if not exists

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 pkg/debian/changelog
+pkg/resources/config-example.yml

--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -62,10 +62,16 @@ func LoadConfig(path string) *Config {
 }
 
 // Write config to a file
-func (c Config) WriteConfig(path string) {
+func (c Config) WriteConfig(path string) error {
 	out, err := yaml.Marshal(c)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not marshal config!")
+		return err
 	}
-	ioutil.WriteFile(path, out, 0600)
+	os.MkdirAll(filepath.Dir(path), 0700)
+	err = ioutil.WriteFile(path, out, 0600)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not write config to disk.")
+	}
+	return err
 }

--- a/cmd/common/config_test.go
+++ b/cmd/common/config_test.go
@@ -40,3 +40,9 @@ func TestLoadNonexistentConfig(t *testing.T) {
 	assert.Equal(t, filepath.Join(home, ".cache/onedriver"), conf.CacheDir)
 	assert.Equal(t, "debug", conf.LogLevel)
 }
+
+func TestWriteConfig(t *testing.T) {
+	t.Parallel()
+	conf := LoadConfig(filepath.Join(configTestDir, "config-test.yml"))
+	assert.NoError(t, conf.WriteConfig("tmp/nested/config.yml"))
+}

--- a/cmd/common/setup_test.go
+++ b/cmd/common/setup_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Chdir("../..")
+	os.RemoveAll("tmp")
 	f, _ := os.OpenFile("fusefs_tests.log", os.O_TRUNC|os.O_CREATE|os.O_RDWR, 0644)
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: f, TimeFormat: "15:04:05"})

--- a/pkg/resources/config-example.yml
+++ b/pkg/resources/config-example.yml
@@ -3,7 +3,7 @@
 # - debug - Log all operations that modify a file or directory.
 # - info - Log "big" operations like uploads and downloads.
 # - warn - These are warnings. Usually not a problem.
-# - error - Things that onedriver doesn't like, but can continue running 
+# - error - Things that onedriver doesn't like, but can continue running
 #          (can possibly result in file corruption or inability to do something).
 # - fatal - Only log errors that kill the program (this log level is not recommended).
 log: debug
@@ -17,6 +17,6 @@ cacheDir: ~/.cache/onedriver
 # default values.
 #auth:
 #  clientID: "3470c3fa-bc10-45ab-a0a9-2d30836485d1"
-#	 codeURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+#  codeURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
 #  tokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
 #  redirectURL: "https://login.live.com/oauth20_desktop.srf"


### PR DESCRIPTION
Fixes an issue where the config directory doesn't get made if it doesn't already exist (it also throws an error message if it fails to write now).