### PR TITLE
Mention the manual page and "onedriver --help" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ NixOS and Nix users can install onedriver from
 either by adding the package to their system's configuration (if they are using
 NixOS) or by installing it manually via `nix-env -iA unstable.onedriver`.
 
-
-
 ## Multiple drives and starting OneDrive on login via systemd
 
 **Note:** You can also set this up through the GUI via the `onedriver-launcher`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ account to Linux with onedriver, and call it a day.
 **Microsoft OneDrive works on Linux.**
 
 Getting started with your files on OneDrive is as easy as running:
-`onedriver /path/to/mount/onedrive/at` (there's also a helpful GUI!).
+`onedriver /path/to/mount/onedrive/at` (there's also a helpful GUI!). To get a
+list of all the arguments onedriver can be run with you can read the manual page
+by typing `man onedriver` or get a quick summary with `onedriver --help`.
 
 ## Key features
 
@@ -140,6 +142,7 @@ NixOS and Nix users can install onedriver from
 [the unstable channel](https://search.nixos.org/packages?channel=unstable&query=onedriver)
 either by adding the package to their system's configuration (if they are using
 NixOS) or by installing it manually via `nix-env -iA unstable.onedriver`.
+
 
 
 ## Multiple drives and starting OneDrive on login via systemd


### PR DESCRIPTION
Extended the paragraph after "Microsoft OneDrive works on Linux" to mention the availability of the man page and "onedriver --help", so users know a way to get a list with all the available arguments to run onedriver.

I thought this would be useful after coming across issue #381. I didn't want to add an explanation with all the parameters because that would just be repetitive when the manpage is more than enough, so this is probably alright.