### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,9 @@ files, you can start onedriver as a systemd user service. In this example,
 mkdir -p $MOUNTPOINT
 export SERVICE_NAME=$(systemd-escape --template onedriver@.service --path $MOUNTPOINT)
 
-# mount onedrive
+# mount onedrive and set it to automatically mount on login
 systemctl --user daemon-reload
-systemctl --user start $SERVICE_NAME
-
-# automatically mount onedrive when you login
-systemctl --user enable $SERVICE_NAME
+systemctl --user enable --now $SERVICE_NAME
 
 # check onedriver's logs for the current day
 journalctl --user -u $SERVICE_NAME --since today


### PR DESCRIPTION
Small README improvement: a systemctl service can be enabled AND started using the `--now` flag