### PR TITLE
Lock opened file inodes to prevent a use after free race condition

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -706,6 +706,10 @@ func (f *Filesystem) Flush(cancel <-chan struct{}, in *fuse.FlushIn) fuse.Status
 		Uint64("nodeID", in.NodeId).
 		Msg("")
 	f.Fsync(cancel, &fuse.FsyncIn{InHeader: in.InHeader})
+
+	// grab a lock to prevent a race condition closing an opened file prior to its use (use after free segfault)
+	inode.Lock()
+	defer inode.Unlock()
 	f.content.Close(id)
 	return 0
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -506,7 +506,11 @@ func (f *Filesystem) Open(cancel <-chan struct{}, in *fuse.OpenIn, out *fuse.Ope
 		ctx.Info().Msg("Found content in cache.")
 
 		// we check size ourselves in case the API file sizes are WRONG (it happens)
-		st, _ := fd.Stat()
+		st, err := fd.Stat()
+		if err != nil {
+			ctx.Error().Err(err).Msg("Could not fetch file stats.")
+			return fuse.EIO
+		}
 		inode.DriveItem.Size = uint64(st.Size())
 		return fuse.OK
 	}


### PR DESCRIPTION
Relates to: https://github.com/jstaf/onedriver/issues/414

There's a race condition where the opened file handlers are getting closed by the `Flush` operation:
https://github.com/jstaf/onedriver/blob/15a1c6426a0cf86be7388cb251d7071c840fe386/fs/fs.go#L705

This PR moves the existed `inode` lock prior to opening the file descriptor and wraps the same inode lock around the fd closure, which prevents the mentioned bug, and handles/reports the un-handled error.