### PR TITLE
Port to libwebkit2gtk-4.1. libwebkit2gtk-4.0 deprecated.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.1
+current_version = 0.14.2
 commit = False
 tag = False
 

--- a/cgo-helper.sh
+++ b/cgo-helper.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 # cgo cannot conditionally use different packages based on which system packages
 # are installed so this script is here to autodetect which webkit2gtk c headers
-# we have access to
+# we have access to.
+# 0.14.2: webkit2gtk-4.0 deprecated on all major distros, so we default to 4.1 now.
+# If you need 4.0 support, use onedriver 0.14.1 or earlier.
 
 if [ -n "$CGO_ENABLED" ] && [ "$CGO_ENABLED" -eq 0 ]; then
     exit 0
 fi
 
-if pkg-config webkit2gtk-4.0; then
-    sed -i 's/webkit2gtk-4.1/webkit2gtk-4.0/g' fs/graph/oauth2_gtk.go
-elif ! pkg-config webkit2gtk-4.1; then
-    echo "webkit2gtk development headers must be installed"
+# 0.14.1: Check for webkit2gtk-4.0 first for backward compatibility
+# We'll keep this code here for a while, but now we default to 4.1
+#if pkg-config webkit2gtk-4.0; then
+#    sed -i 's/webkit2gtk-4.1/webkit2gtk-4.0/g' fs/graph/oauth2_gtk.go
+#elif ! pkg-config webkit2gtk-4.1; then
+#    echo "webkit2gtk development headers must be installed"
+#    exit 1
+#fi
+
+# 0.14.2: Check for webkit2gtk-4.1
+if ! pkg-config webkit2gtk-4.1; then
+    echo "webkit2gtk-4.1 development headers must be installed"
     exit 1
 fi

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const version = "0.14.1"
+const version = "0.14.2"
 
 var commit string
 

--- a/onedriver.spec
+++ b/onedriver.spec
@@ -1,5 +1,5 @@
 Name:          onedriver
-Version:       0.14.1
+Version:       0.14.2
 Release:       1%{?dist}
 Summary:       A native Linux filesystem for Microsoft Onedrive
 
@@ -15,7 +15,7 @@ BuildRequires: golang >= 1.17.0
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: pkg-config
-BuildRequires: webkit2gtk3-devel
+BuildRequires: pkgconfig(webkit2gtk-4.1)
 Requires: fuse3
 
 %description
@@ -71,6 +71,10 @@ cp pkg/resources/%{name}.1.gz %{buildroot}/usr/share/man/man1
 %attr(644, root, root) /usr/share/man/man1/%{name}.1.gz
 
 %changelog
+* Tue Dec 30 2025 Henrique Cesar Ulbrich <devel@upsec.com.br> = 0.14.2
+- Port to libwebkit2gtk-4.1 and libsoup3, as onedriver was not building in newer distros.
+- cgo-helper was simplified to reject libwebkit2gtk-4.0.
+
 * Wed Oct 18 2023 Jeff Stafford <jeff.stafford@protonmail.com> - 0.14.1
 - Fixes a bug with file corruption in some scenarios from version 0.14.0.
 

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,3 +1,11 @@
+onedriver (0.14.2-1) noble; urgency=low
+
+  * Port to libwebkit2gtk-4.1 and libsoup3, as onedriver was not building on newer distros.
+  * cgo-helper was simplified to reject libwebkit2gtk-4.0.
+
+ -- Henrique Cesar Ulbrich <devel@upsec.com.br> Tue, 30 Dec 2025 01:00 -0300
+
+
 onedriver (0.14.1-1) jammy; urgency=low
 
   * Fixes a bug with file corruption in some scenarios from version 0.14.0.

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -2,7 +2,7 @@ Source: onedriver
 Section: utils
 Priority: optional
 Maintainer: Jeff Stafford <jeff.stafford@protonmail.com>
-Build-Depends: golang (>= 1.15), gcc, pkg-config, libwebkit2gtk-4.0-dev, git, debhelper
+Build-Depends: golang (>= 1.15), gcc, pkg-config, libwebkit2gtk-4.1-dev, git, debhelper
 Standards-Version: 4.4.1
 Homepage: https://github.com/jstaf/onedriver
 #Vcs-Browser: https://github.com/jstaf/onedriver
@@ -10,7 +10,7 @@ Homepage: https://github.com/jstaf/onedriver
 
 Package: onedriver
 Architecture: any
-Depends: libwebkit2gtk-4.0-37, fuse3
+Depends: libwebkit2gtk-4.1-0, fuse3
 Suggests: systemd
 Description:
   A native Linux filesystem for Microsoft Onedrive Onedriver is a native Linux

--- a/pkg/resources/onedriver.1
+++ b/pkg/resources/onedriver.1
@@ -1,6 +1,6 @@
 .\" Manpage for onedriver
 
-.TH man 1 "Nov 2021" "0.14.1" "onedriver man page"
+.TH man 1 "Nov 2021" "0.14.2" "onedriver man page"
 
 .SH NAME
 onedriver \- A native Linux client for Microsoft OneDrive.


### PR DESCRIPTION
Newer distros deprecated libwebkit2gtk-4.0 and libsoup2, so it was impossible to build on them.
The code now calls libwebkit2gtk-4.1. 
Not a big deal, but needs testing.

It built and run on a Ubuntu 24.04.3 LTS, but needs to be tested on SuSE, RH and Debian.
On Ubuntu, it built withot errors and was able to mount a OneDrive share, download and upload files without corruption. 