### PR TITLE
Fix security bugs in oauth2_gtk.c

### DIFF
--- a/fs/graph/oauth2_gtk.c
+++ b/fs/graph/oauth2_gtk.c
@@ -23,7 +23,7 @@ char *uri_get_host(char *uri) {
             start = i + 1;
         } else if (start > 0) {
             int len = i - start;
-            char *host = malloc(len);
+            char *host = malloc(len + 1);
             strncpy(host, uri + start, len);
             host[len] = '\0';
             return host;
@@ -80,12 +80,15 @@ static gboolean web_view_load_failed_tls(WebKitWebView *web_view, char *failing_
         reason = "G_TLS_CERTIFICATE_GENERIC_ERROR - Some other error occurred validating "
                  "the certificate.";
         break;
-    default:
-        snprintf(reason, 256,
+    default: {
+        static char buf[256];
+        snprintf(buf, sizeof(buf),
                  "Multiple failures (%d) - There were multiple errors during certificate "
                  "verification.",
                  errors);
+        reason = buf;
         break;
+    }
     }
 
     g_print("Webkit load failed with TLS errors for %s : %s\n", failing_uri, reason);


### PR DESCRIPTION
### 1. Heap buffer overflow in `uri_get_host()` 

```c
// ❌ Before
char *host = malloc(len);     // allocates len bytes
strncpy(host, uri + start, len); // Write 'len' bytes
host[len] = '\0';              // writes OUTSIDE the buffer 1 extra byte (\0)
```

`malloc(len)` allocates exactly `len` bytes, but `host[len] = '\0'` writes at
position `len` — **1 byte past** the allocated block. 

**Fix:** `malloc(len + 1)`

### 2. Uninitialized pointer in `web_view_load_failed_tls()` 

```c
// ❌ Before
char *reason;                  // uninitialized pointer (stack garbage)
// ...
default:
    snprintf(reason, 256, ...); // writes to garbage address → undefined behavior
```

`char *reason` is an automatic local variable that never receives allocated
memory. In the `default` case, `snprintf(reason, 256, ...)` writes 256 bytes
to an unpredictable address. This can cause stack corruption, crashes, or
potentially be exploitable.

**Fix:** Use a static buffer inside the `default` block so `snprintf` has valid
memory to write to while preserving the diagnostic error code output.
