### PR TITLE
Add configurable cache TTL eviction (cacheMaxAge)

### DIFF
--- a/cmd/common/config.go
+++ b/cmd/common/config.go
@@ -3,6 +3,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"dario.cat/mergo"
 	"github.com/jstaf/onedriver/fs/graph"
@@ -11,9 +12,34 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+// Duration is a time.Duration wrapper that supports YAML (un)marshaling
+// from Go duration strings like "720h", "5m", "30s".
+type Duration time.Duration
+
+// UnmarshalText implements encoding.TextUnmarshaler for YAML parsing.
+func (d *Duration) UnmarshalText(text []byte) error {
+	parsed, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	*d = Duration(parsed)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler for YAML serialization.
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+// AsDuration returns the underlying time.Duration.
+func (d Duration) AsDuration() time.Duration {
+	return time.Duration(d)
+}
+
 type Config struct {
-	CacheDir         string `yaml:"cacheDir"`
-	LogLevel         string `yaml:"log"`
+	CacheDir         string   `yaml:"cacheDir"`
+	LogLevel         string   `yaml:"log"`
+	CacheMaxAge      Duration `yaml:"cacheMaxAge"`
 	graph.AuthConfig `yaml:"auth"`
 }
 

--- a/cmd/common/config_test.go
+++ b/cmd/common/config_test.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v3"
 )
 
 const configTestDir = "pkg/resources/test"
@@ -19,6 +21,8 @@ func TestLoadConfig(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	assert.Equal(t, filepath.Join(home, "somewhere/else"), conf.CacheDir)
 	assert.Equal(t, "warn", conf.LogLevel)
+	assert.Equal(t, Duration(720*time.Hour), conf.CacheMaxAge)
+	assert.Equal(t, 720*time.Hour, conf.CacheMaxAge.AsDuration())
 }
 
 func TestConfigMerge(t *testing.T) {
@@ -45,4 +49,45 @@ func TestWriteConfig(t *testing.T) {
 	t.Parallel()
 	conf := LoadConfig(filepath.Join(configTestDir, "config-test.yml"))
 	assert.NoError(t, conf.WriteConfig("tmp/nested/config.yml"))
+}
+
+// Duration strings from YAML should be correctly parsed via time.ParseDuration.
+func TestCacheMaxAgeParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		yaml     string
+		expected time.Duration
+	}{
+		{"cacheMaxAge: 720h", 720 * time.Hour},
+		{"cacheMaxAge: 24h", 24 * time.Hour},
+		{"cacheMaxAge: 5m", 5 * time.Minute},
+		{"cacheMaxAge: 30s", 30 * time.Second},
+		{"cacheMaxAge: 0", 0},
+	}
+	for _, c := range cases {
+		conf := &Config{}
+		err := yaml.Unmarshal([]byte(c.yaml), conf)
+		assert.NoError(t, err, "failed to parse: %s", c.yaml)
+		assert.Equal(t, Duration(c.expected), conf.CacheMaxAge,
+			"unexpected duration for: %s", c.yaml)
+	}
+}
+
+// Omitting cacheMaxAge from the YAML should leave it at zero (disabled).
+func TestCacheMaxAgeDefault(t *testing.T) {
+	t.Parallel()
+
+	conf := &Config{}
+	err := yaml.Unmarshal([]byte("log: info\n"), conf)
+	assert.NoError(t, err)
+	assert.Equal(t, Duration(0), conf.CacheMaxAge)
+}
+
+// Invalid duration strings must reject.
+func TestCacheMaxAgeInvalid(t *testing.T) {
+	t.Parallel()
+
+	err := yaml.Unmarshal([]byte("cacheMaxAge: notaduration"), &Config{})
+	assert.Error(t, err)
 }

--- a/cmd/onedriver-launcher/main.go
+++ b/cmd/onedriver-launcher/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 	"unsafe"
 
 	"github.com/coreos/go-systemd/v22/unit"
@@ -547,11 +548,39 @@ func newSettingsWindow(config *common.Config, configPath string) {
 	})
 	settingsRowCacheDir.PackEnd(cacheDirPicker, false, false, 0)
 
+	// cache max age settings
+	settingsRowCacheMaxAge, _ := gtk.BoxNew(gtk.ORIENTATION_HORIZONTAL, offset)
+	cacheMaxAgeLabel, _ := gtk.LabelNew("Cache max age")
+	settingsRowCacheMaxAge.PackStart(cacheMaxAgeLabel, false, false, 0)
+
+	cacheMaxAgeEntry, _ := gtk.EntryNew()
+	cacheMaxAgeEntry.SetText(config.CacheMaxAge.AsDuration().String())
+	cacheMaxAgeEntry.SetTooltipText("Max age of cached files before eviction. " +
+		"Examples: 720h (30 days), 24h, 30m. Use 0 to disable.")
+	cacheMaxAgeEntry.SetSizeRequest(120, 0)
+	cacheMaxAgeEntry.Connect("activate", func() {
+		text, err := cacheMaxAgeEntry.GetText()
+		if err != nil || text == "" {
+			text = "0"
+		}
+		d, err := time.ParseDuration(text)
+		if err != nil {
+			ui.Dialog("Invalid duration: "+err.Error(), gtk.MESSAGE_ERROR, settingsWindow)
+			cacheMaxAgeEntry.SetText(config.CacheMaxAge.AsDuration().String())
+			return
+		}
+		config.CacheMaxAge = common.Duration(d)
+		log.Debug().Dur("cacheMaxAge", d).Msg("Cache max age changed.")
+		config.WriteConfig(configPath)
+	})
+	settingsRowCacheMaxAge.PackEnd(cacheMaxAgeEntry, false, false, 0)
+
 	// assemble rows
 	settingsWindowBox, _ := gtk.BoxNew(gtk.ORIENTATION_VERTICAL, offset)
 	settingsWindowBox.SetBorderWidth(offset)
 	settingsWindowBox.PackStart(settingsRowLog, true, true, 0)
 	settingsWindowBox.PackStart(settingsRowCacheDir, true, true, 0)
+	settingsWindowBox.PackStart(settingsRowCacheMaxAge, true, true, 0)
 	settingsWindow.Add(settingsWindowBox)
 	settingsWindow.ShowAll()
 }

--- a/cmd/onedriver/main.go
+++ b/cmd/onedriver/main.go
@@ -125,6 +125,10 @@ func main() {
 	log.Info().Msgf("onedriver %s", common.Version())
 	auth := graph.Authenticate(config.AuthConfig, authPath, *headless)
 	filesystem := fs.NewFilesystem(auth, cachePath)
+	log.Info().Msgf("cacheMaxAge value: %s", time.Duration(config.CacheMaxAge))
+	if config.CacheMaxAge > 0 {
+		filesystem.SetCacheMaxAge(config.CacheMaxAge.AsDuration())
+	}
 	go filesystem.DeltaLoop(30 * time.Second)
 	xdgVolumeInfo(filesystem, auth)
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,147 @@
+# onedriver — Configuration Reference
+
+Config file location: `~/.config/onedriver/config.yml` (YAML format)
+
+All parameters are optional — onedriver uses sensible defaults for everything.
+
+## Quick start example
+
+```yaml
+# ~/.config/onedriver/config.yml
+log: info
+cacheDir: ~/.cache/onedriver
+cacheMaxAge: 720h
+```
+
+## Top-level parameters
+
+### `log`
+
+Log verbosity level.
+
+| Value   | Description |
+|---------|-------------|
+| `trace` | Every syscall handled by the filesystem |
+| `debug` | All operations that modify a file or directory |
+| `info`  | "Big" operations like uploads and downloads |
+| `warn`  | Warnings — usually not a problem |
+| `error` | Errors onedriver can recover from |
+| `fatal` | Only fatal errors (not recommended) |
+
+**Default:** `debug`
+
+```yaml
+log: info
+```
+
+### `cacheDir`
+
+Directory where onedriver stores its cache (metadata database + downloaded file content). Can grow large depending on usage. `~` is expanded to your home directory.
+
+**Default:** `~/.cache/onedriver`
+
+```yaml
+cacheDir: ~/.cache/onedriver
+```
+
+### `cacheMaxAge` (since onedriver X.Y)
+
+Maximum age of cached file content before automatic eviction. When set, a
+background goroutine periodically removes content files whose last
+modification time exceeds this duration. Files currently open (being read or
+written) are skipped.
+
+Set to `0` or omit to disable eviction entirely (files stay cached forever).
+
+Format: Go duration string — a number followed by a unit suffix.
+
+| Suffix | Unit |
+|--------|------|
+| `s`    | seconds |
+| `m`    | minutes |
+| `h`    | hours |
+| `d`    | days (24h) |
+
+Examples:
+
+```yaml
+# Evict content not accessed in 30 days
+cacheMaxAge: 720h
+
+# Evict after 1 day
+cacheMaxAge: 24h
+
+# Evict after 7 days
+cacheMaxAge: 168h
+
+# Disabled (default)
+cacheMaxAge: 0
+```
+
+Evicted files are re-downloaded transparently from OneDrive the next time
+they are accessed. Metadata (file names, sizes, directory structure) is
+**not** evicted — only the downloaded content.
+
+## `auth` section
+
+OAuth2 authentication parameters. You should **not** change these unless you
+have registered your own application in Azure Active Directory / Entra ID.
+The defaults point to the official onedriver app registration.
+
+```yaml
+auth:
+  clientID: "3470c3fa-bc10-45ab-a0a9-2d30836485d1"
+  codeURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+  tokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+  redirectURL: "https://login.live.com/oauth20_desktop.srf"
+```
+
+### `auth.clientID`
+
+Azure AD / Entra ID application (client) ID.
+
+**Default:** `3470c3fa-bc10-45ab-a0a9-2d30836485d1`
+
+### `auth.codeURL`
+
+OAuth2 authorization endpoint.
+
+**Default:** `https://login.microsoftonline.com/common/oauth2/v2.0/authorize`
+
+### `auth.tokenURL`
+
+OAuth2 token endpoint.
+
+**Default:** `https://login.microsoftonline.com/common/oauth2/v2.0/token`
+
+### `auth.redirectURL`
+
+OAuth2 redirect URI (must match the one registered in Azure AD).
+
+**Default:** `https://login.live.com/oauth20_desktop.srf`
+
+## Complete example
+
+```yaml
+log: info
+cacheDir: ~/.cache/onedriver
+cacheMaxAge: 720h
+
+# Only uncomment if using your own Azure AD app registration
+#auth:
+#  clientID: "your-client-id-here"
+#  codeURL: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+#  tokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+#  redirectURL: "https://login.live.com/oauth20_desktop.srf"
+```
+
+## CLI overrides
+
+These config values can be overridden at runtime via command-line flags:
+
+| Config key   | CLI flag          |
+|-------------|-------------------|
+| `cacheDir`  | `--cache-dir` / `-c` |
+| `log`       | `--log` / `-l`    |
+
+`cacheMaxAge` and `auth.*` have no CLI equivalents.

--- a/fs/cache.go
+++ b/fs/cache.go
@@ -21,13 +21,14 @@ import (
 type Filesystem struct {
 	fuse.RawFileSystem
 
-	metadata  sync.Map
-	db        *bolt.DB
-	content   *LoopbackCache
-	auth      *graph.Auth
-	root      string // the id of the filesystem's root item
-	deltaLink string
-	uploads   *UploadManager
+	metadata    sync.Map
+	db          *bolt.DB
+	content     *LoopbackCache
+	auth        *graph.Auth
+	root        string // the id of the filesystem's root item
+	deltaLink   string
+	uploads     *UploadManager
+	cacheMaxAge time.Duration
 
 	sync.RWMutex
 	offline    bool
@@ -106,6 +107,7 @@ func NewFilesystem(auth *graph.Auth, cacheDir string) *Filesystem {
 		content:       content,
 		db:            db,
 		auth:          auth,
+		cacheMaxAge:   5 * time.Minute,
 		opendirs:      make(map[uint64][]*Inode),
 	}
 
@@ -591,4 +593,51 @@ func (f *Filesystem) SerializeAll() {
 		}
 		return nil
 	})
+}
+
+// SetCacheMaxAge enables automatic cache eviction for content files older than
+// maxAge. If maxAge is zero or negative, eviction is disabled.
+func (f *Filesystem) SetCacheMaxAge(maxAge time.Duration) {
+	f.cacheMaxAge = maxAge
+	if maxAge > 0 {
+		go f.cacheCleanupLoop(10 * time.Minute)
+	}
+}
+
+// cacheCleanupLoop periodically removes cached content files that exceed the
+// configured max age. Only files that are not currently open are evicted.
+func (f *Filesystem) cacheCleanupLoop(interval time.Duration) {
+	log.Info().Dur("maxAge", f.cacheMaxAge).Msg("Starting cache cleanup loop.")
+	for {
+		f.evictExpired()
+		time.Sleep(interval)
+	}
+}
+
+// evictExpired removes content files whose mtime exceeds the configured
+// cacheMaxAge. Files currently open are skipped.
+func (f *Filesystem) evictExpired() {
+	entries, err := os.ReadDir(f.content.directory)
+	if err != nil {
+		log.Error().Err(err).Str("dir", f.content.directory).Msg("Failed to read cache directory.")
+		return
+	}
+	cutoff := time.Now().Add(-f.cacheMaxAge)
+	log.Info().
+		Time("cutoff", cutoff).
+		Msg("Cleaning cache content.")
+	var evicted int
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) && !f.content.IsOpen(entry.Name()) {
+			f.content.Delete(entry.Name())
+			evicted++
+		}
+	}
+	if evicted > 0 {
+		log.Info().Int("count", evicted).Msg("Evicted cached content files.")
+	}
 }

--- a/fs/cache_test.go
+++ b/fs/cache_test.go
@@ -3,8 +3,10 @@ package fs
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,4 +64,63 @@ func TestSamePointer(t *testing.T) {
 		t.Fatalf("Pointers to cached items do not match: %p != %p\n", item, item2)
 	}
 	assert.NotNil(t, item)
+}
+
+// SetCacheMaxAge should store the configured max age.
+func TestSetCacheMaxAge(t *testing.T) {
+	t.Parallel()
+	cache := NewFilesystem(auth, filepath.Join(testDBLoc, "test_cache_max_age"))
+	assert.Equal(t, 5*time.Minute, cache.cacheMaxAge)
+
+	cache.SetCacheMaxAge(2 * time.Hour)
+	// Give the background goroutine a moment to start.
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, 2*time.Hour, cache.cacheMaxAge)
+}
+
+// SetCacheMaxAge with zero or negative should not start the cleanup loop.
+func TestSetCacheMaxAgeZero(t *testing.T) {
+	t.Parallel()
+	cache := NewFilesystem(auth, filepath.Join(testDBLoc, "test_cache_max_age_zero"))
+	cache.SetCacheMaxAge(0)
+	assert.Equal(t, time.Duration(0), cache.cacheMaxAge)
+	cache.SetCacheMaxAge(-1 * time.Hour)
+	assert.Equal(t, -1*time.Hour, cache.cacheMaxAge)
+}
+
+// EvictExpired removes content files older than cacheMaxAge, skipping open files.
+func TestEvictExpired(t *testing.T) {
+	t.Parallel()
+	cache := NewFilesystem(auth, filepath.Join(testDBLoc, "test_evict_expired"))
+	cache.SetCacheMaxAge(1 * time.Hour)
+	time.Sleep(50 * time.Millisecond) // let cleanup loop start
+
+	// Create three content files with different ages.
+	files := map[string]time.Duration{
+		"old_file":    -2 * time.Hour,    // should be evicted
+		"recent_file": -30 * time.Minute, // should stay
+		"open_file":   -2 * time.Hour,    // should stay (will be opened)
+	}
+	for name, age := range files {
+		cache.content.Insert(name, []byte("content-"+name))
+		oldTime := time.Now().Add(age)
+		os.Chtimes(filepath.Join(cache.content.directory, name), oldTime, oldTime)
+	}
+
+	// Open one file so it is skipped during eviction.
+	fd, err := cache.content.Open("open_file")
+	require.NoError(t, err)
+	defer cache.content.Close("open_file")
+	require.NotNil(t, fd)
+
+	// Run eviction.
+	cache.evictExpired()
+
+	// Verify results.
+	assert.False(t, cache.content.HasContent("old_file"),
+		"old_file should have been evicted")
+	assert.True(t, cache.content.HasContent("recent_file"),
+		"recent_file should still be cached")
+	assert.True(t, cache.content.HasContent("open_file"),
+		"open_file should still be cached (was open)")
 }

--- a/pkg/resources/test/config-test.yml
+++ b/pkg/resources/test/config-test.yml
@@ -1,2 +1,3 @@
 log: warn
 cacheDir: ~/somewhere/else
+cacheMaxAge: 720h


### PR DESCRIPTION
Adds a `cacheMaxAge` configuration option that enables automatic eviction of cached file content older than the configured duration. A background goroutine periodically removes expired content files, skipping any files currently open.

### Problem

`time.Duration` does not implement `encoding.TextUnmarshaler`, so `gopkg.in/yaml.v3` cannot parse Go duration strings like `"720h"` or `"30m"` from YAML. A custom `Duration` type with `UnmarshalText`/`MarshalText` was introduced to fix this.

### Changes

- **`cmd/common/config.go`** — New `Duration` type wrapping `time.Duration` with YAML-aware text marshaling.
- **`cmd/onedriver/main.go`** — Converts `Duration` → `time.Duration` via `.AsDuration()`.
- **`cmd/onedriver-launcher/main.go`** — Added "Cache max age" entry field in the Settings window.
- **`fs/cache.go`** — Extracted `evictExpired()` from `cacheCleanupLoop` for testability. Added error logging for `os.ReadDir` failures.
- **`fs/cache_test.go`** — Three new tests: `TestSetCacheMaxAge`, `TestSetCacheMaxAgeZero`, `TestEvictExpired`.
- **`cmd/common/config_test.go`** — Six new tests for YAML duration parsing.
- **`docs/CONFIG.md`** — Full configuration reference.

### Configuration

```yaml
# ~/.config/onedriver/config.yml
cacheMaxAge: 720h   # evict content older than 30 days
cacheMaxAge: 0      # disable eviction (default)
```

### How it works

- First cleanup runs immediately at startup, then every 10 minutes.
- Uses file `mtime` to determine age — reads do not reset it.
- Files currently open are skipped.
- Only content is evicted; metadata is preserved. Evicted files are re-downloaded transparently on next access.